### PR TITLE
[SCRUM-211] 음식(Food) 데이터베이스 수정

### DIFF
--- a/Assets/ScriptableObjects/FoodObjectSO/FoodDatabase.asset
+++ b/Assets/ScriptableObjects/FoodObjectSO/FoodDatabase.asset
@@ -13,619 +13,619 @@ MonoBehaviour:
   m_Name: FoodDatabase
   m_EditorClassIdentifier: 
   foodData:
-  - <Name>k__BackingField: Water
+  - <name>k__BackingField: Water
     <food>k__BackingField: 13
     <tag>k__BackingField: 0
-    <ID>k__BackingField: 1
+    <id>k__BackingField: 0
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
-    <Prefab>k__BackingField: {fileID: 7658888424487957560, guid: 858d6f087e4884a44828a9972ebd862c, type: 3}
+    <prefab>k__BackingField: {fileID: 7658888424487957560, guid: 858d6f087e4884a44828a9972ebd862c, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: 57c41c1f12c2445b2ba2dd9188b3d3d9, type: 3}
-  - <Name>k__BackingField: Vinegar
+  - <name>k__BackingField: Vinegar
     <food>k__BackingField: 12
     <tag>k__BackingField: 0
-    <ID>k__BackingField: 2
+    <id>k__BackingField: 1
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
-    <Prefab>k__BackingField: {fileID: 7497115926558726248, guid: fdd184d5328a04b2d92528018c2a4579, type: 3}
+    <prefab>k__BackingField: {fileID: 7497115926558726248, guid: fdd184d5328a04b2d92528018c2a4579, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: ea81d37d2c27b47458683d2bf90822d8, type: 3}
-  - <Name>k__BackingField: Soysauce
+  - <name>k__BackingField: Soysauce
     <food>k__BackingField: 15
     <tag>k__BackingField: 0
-    <ID>k__BackingField: 3
+    <id>k__BackingField: 2
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
-    <Prefab>k__BackingField: {fileID: 3202690755826013567, guid: 6795187f7503a4d59bec7eab34307513, type: 3}
+    <prefab>k__BackingField: {fileID: 3202690755826013567, guid: 6795187f7503a4d59bec7eab34307513, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: 38277244fda184b3f9bf001bee1a912b, type: 3}
-  - <Name>k__BackingField: Miso
+  - <name>k__BackingField: Miso
     <food>k__BackingField: 16
     <tag>k__BackingField: 0
-    <ID>k__BackingField: 4
+    <id>k__BackingField: 3
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
-    <Prefab>k__BackingField: {fileID: 3505866646548267482, guid: ae6fe198d936542298b80a2e4d2ecee8, type: 3}
+    <prefab>k__BackingField: {fileID: 3505866646548267482, guid: ae6fe198d936542298b80a2e4d2ecee8, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: be352e9356ef64e15bc73c86d3ac587a, type: 3}
-  - <Name>k__BackingField: Rice
+  - <name>k__BackingField: Rice
     <food>k__BackingField: 0
     <tag>k__BackingField: 0
-    <ID>k__BackingField: 5
+    <id>k__BackingField: 4
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
-    <Prefab>k__BackingField: {fileID: 9083243063744714783, guid: dc7a29cfd1e3d423186054b30dede15b, type: 3}
+    <prefab>k__BackingField: {fileID: 9083243063744714783, guid: dc7a29cfd1e3d423186054b30dede15b, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: 4ed82be0d8c3d45f1a9979a7ddca8537, type: 3}
-  - <Name>k__BackingField: FryPowder
+  - <name>k__BackingField: FryPowder
     <food>k__BackingField: 17
     <tag>k__BackingField: 0
-    <ID>k__BackingField: 6
+    <id>k__BackingField: 5
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
-    <Prefab>k__BackingField: {fileID: 7658888424487957560, guid: 858d6f087e4884a44828a9972ebd862c, type: 3}
+    <prefab>k__BackingField: {fileID: 7658888424487957560, guid: 858d6f087e4884a44828a9972ebd862c, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: 6c93784436b1545bcb48efed094102c3, type: 3}
-  - <Name>k__BackingField: Noodle
+  - <name>k__BackingField: Noodle
     <food>k__BackingField: 14
     <tag>k__BackingField: 0
-    <ID>k__BackingField: 7
+    <id>k__BackingField: 6
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
-    <Prefab>k__BackingField: {fileID: 3067885276403880707, guid: 2e5c95145ab3842ac904f2aba75af068, type: 3}
+    <prefab>k__BackingField: {fileID: 3067885276403880707, guid: 2e5c95145ab3842ac904f2aba75af068, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: 44fbece8093fc4361bd7815195eeddd5, type: 3}
-  - <Name>k__BackingField: Tofu
+  - <name>k__BackingField: Tofu
     <food>k__BackingField: 2
     <tag>k__BackingField: 0
-    <ID>k__BackingField: 8
+    <id>k__BackingField: 7
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
-    <Prefab>k__BackingField: {fileID: 2569467188940230205, guid: 62fe09e6fdfc348a5ae1c6a52f799241, type: 3}
+    <prefab>k__BackingField: {fileID: 2569467188940230205, guid: 62fe09e6fdfc348a5ae1c6a52f799241, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: 3042022ba4748422fbc4760a27398995, type: 3}
-  - <Name>k__BackingField: Egg
+  - <name>k__BackingField: Egg
     <food>k__BackingField: 1
     <tag>k__BackingField: 0
-    <ID>k__BackingField: 9
+    <id>k__BackingField: 8
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
-    <Prefab>k__BackingField: {fileID: 8389371753922280744, guid: d2325c2c59a9444009c2bc43ac13061c, type: 3}
+    <prefab>k__BackingField: {fileID: 8389371753922280744, guid: d2325c2c59a9444009c2bc43ac13061c, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: d51a4ac8e10bb49eb87772998006c838, type: 3}
-  - <Name>k__BackingField: Pork
+  - <name>k__BackingField: Pork
     <food>k__BackingField: 11
     <tag>k__BackingField: 0
-    <ID>k__BackingField: 10
+    <id>k__BackingField: 9
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
-    <Prefab>k__BackingField: {fileID: 6881908385715226372, guid: 0b846b3416f4d412090b11f4bc22ab0f, type: 3}
+    <prefab>k__BackingField: {fileID: 6881908385715226372, guid: 0b846b3416f4d412090b11f4bc22ab0f, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: ea8db274cc03b41928a6284e9ef5ae8e, type: 3}
-  - <Name>k__BackingField: Beef
+  - <name>k__BackingField: Beef
     <food>k__BackingField: 6
     <tag>k__BackingField: 0
-    <ID>k__BackingField: 11
+    <id>k__BackingField: 10
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
-    <Prefab>k__BackingField: {fileID: 6274084391122988245, guid: 9eee2e4b908a24ffa889fc49be8cc8a6, type: 3}
+    <prefab>k__BackingField: {fileID: 6274084391122988245, guid: 9eee2e4b908a24ffa889fc49be8cc8a6, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: 07456d10633e04d71853135c3bf52878, type: 3}
-  - <Name>k__BackingField: Shrimp
+  - <name>k__BackingField: Shrimp
     <food>k__BackingField: 4
     <tag>k__BackingField: 0
-    <ID>k__BackingField: 12
+    <id>k__BackingField: 11
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
-    <Prefab>k__BackingField: {fileID: 2604253987008481563, guid: 872801591ea4445e59b45584beca57c6, type: 3}
+    <prefab>k__BackingField: {fileID: 2604253987008481563, guid: 872801591ea4445e59b45584beca57c6, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: 8f59dc0b9a3ee4c87bf5d4d3fcf59eb8, type: 3}
-  - <Name>k__BackingField: Vegetable
+  - <name>k__BackingField: Vegetable
     <food>k__BackingField: 19
     <tag>k__BackingField: 0
-    <ID>k__BackingField: 13
+    <id>k__BackingField: 12
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
-    <Prefab>k__BackingField: {fileID: 1843141169661942814, guid: d278d01a1c3f6416f95c5c53eb3f1fdb, type: 3}
+    <prefab>k__BackingField: {fileID: 1843141169661942814, guid: d278d01a1c3f6416f95c5c53eb3f1fdb, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: eb8bd001eadaa40eeb8010278dac92e0, type: 3}
-  - <Name>k__BackingField: Flatfish
+  - <name>k__BackingField: Flatfish
     <food>k__BackingField: 3
     <tag>k__BackingField: 0
-    <ID>k__BackingField: 14
+    <id>k__BackingField: 13
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
-    <Prefab>k__BackingField: {fileID: 5773488423304670987, guid: a8fb2a1e56c1f41699379752eb62a4ce, type: 3}
+    <prefab>k__BackingField: {fileID: 5773488423304670987, guid: a8fb2a1e56c1f41699379752eb62a4ce, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: a7ebe0897cc8b4fe9be4d6d94df071c2, type: 3}
-  - <Name>k__BackingField: Saba
+  - <name>k__BackingField: Saba
     <food>k__BackingField: 5
     <tag>k__BackingField: 0
-    <ID>k__BackingField: 15
+    <id>k__BackingField: 14
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
-    <Prefab>k__BackingField: {fileID: 5773488423304670987, guid: a8fb2a1e56c1f41699379752eb62a4ce, type: 3}
+    <prefab>k__BackingField: {fileID: 5773488423304670987, guid: a8fb2a1e56c1f41699379752eb62a4ce, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: a7ebe0897cc8b4fe9be4d6d94df071c2, type: 3}
-  - <Name>k__BackingField: Tuna
+  - <name>k__BackingField: Tuna
     <food>k__BackingField: 7
     <tag>k__BackingField: 0
-    <ID>k__BackingField: 16
+    <id>k__BackingField: 15
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
-    <Prefab>k__BackingField: {fileID: 5773488423304670987, guid: a8fb2a1e56c1f41699379752eb62a4ce, type: 3}
+    <prefab>k__BackingField: {fileID: 5773488423304670987, guid: a8fb2a1e56c1f41699379752eb62a4ce, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: a7ebe0897cc8b4fe9be4d6d94df071c2, type: 3}
-  - <Name>k__BackingField: Salmon
+  - <name>k__BackingField: TunaDoro
+    <food>k__BackingField: 8
+    <tag>k__BackingField: 0
+    <id>k__BackingField: 16
+    <price>k__BackingField: 1000
+    <level>k__BackingField: 1
+    <prefab>k__BackingField: {fileID: 5773488423304670987, guid: a8fb2a1e56c1f41699379752eb62a4ce, type: 3}
+    <icon>k__BackingField: {fileID: 2800000, guid: a7ebe0897cc8b4fe9be4d6d94df071c2, type: 3}
+  - <name>k__BackingField: Salmon
     <food>k__BackingField: 9
     <tag>k__BackingField: 0
-    <ID>k__BackingField: 17
+    <id>k__BackingField: 17
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
-    <Prefab>k__BackingField: {fileID: 5773488423304670987, guid: a8fb2a1e56c1f41699379752eb62a4ce, type: 3}
+    <prefab>k__BackingField: {fileID: 5773488423304670987, guid: a8fb2a1e56c1f41699379752eb62a4ce, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: a7ebe0897cc8b4fe9be4d6d94df071c2, type: 3}
-  - <Name>k__BackingField: Unagi
+  - <name>k__BackingField: Unagi
     <food>k__BackingField: 10
     <tag>k__BackingField: 0
-    <ID>k__BackingField: 18
+    <id>k__BackingField: 18
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
-    <Prefab>k__BackingField: {fileID: 5773488423304670987, guid: a8fb2a1e56c1f41699379752eb62a4ce, type: 3}
+    <prefab>k__BackingField: {fileID: 5773488423304670987, guid: a8fb2a1e56c1f41699379752eb62a4ce, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: a7ebe0897cc8b4fe9be4d6d94df071c2, type: 3}
-  - <Name>k__BackingField: CookedRicePot
+  - <name>k__BackingField: VinegarRice
     <food>k__BackingField: 60
     <tag>k__BackingField: 1
-    <ID>k__BackingField: 19
+    <id>k__BackingField: 100
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
-    <Prefab>k__BackingField: {fileID: 7696103292884469837, guid: 6f5ea644a7dfd4694899f70d65628207, type: 3}
+    <prefab>k__BackingField: {fileID: 0}
     <icon>k__BackingField: {fileID: 0}
-  - <Name>k__BackingField: CookedRice
+  - <name>k__BackingField: CookedRice
     <food>k__BackingField: 58
     <tag>k__BackingField: 1
-    <ID>k__BackingField: 20
+    <id>k__BackingField: 101
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
-    <Prefab>k__BackingField: {fileID: 4323809633325535547, guid: d4c4c6549a0c14d58ba1fb9dce93a8d6, type: 3}
+    <prefab>k__BackingField: {fileID: 4323809633325535547, guid: d4c4c6549a0c14d58ba1fb9dce93a8d6, type: 3}
     <icon>k__BackingField: {fileID: 0}
-  - <Name>k__BackingField: EggRoll
+  - <name>k__BackingField: EggRoll
     <food>k__BackingField: 61
     <tag>k__BackingField: 1
-    <ID>k__BackingField: 21
+    <id>k__BackingField: 102
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
-    <Prefab>k__BackingField: {fileID: 9032505915419756735, guid: 37906f56bca534bc49351cf1bb17ed10, type: 3}
+    <prefab>k__BackingField: {fileID: 9032505915419756735, guid: 37906f56bca534bc49351cf1bb17ed10, type: 3}
     <icon>k__BackingField: {fileID: 0}
-  - <Name>k__BackingField: FriedTofu
+  - <name>k__BackingField: FriedTofu
     <food>k__BackingField: 63
     <tag>k__BackingField: 1
-    <ID>k__BackingField: 22
+    <id>k__BackingField: 103
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
-    <Prefab>k__BackingField: {fileID: 7153209375705375888, guid: db231e412588d46e2a526846be501bf8, type: 3}
+    <prefab>k__BackingField: {fileID: 7153209375705375888, guid: db231e412588d46e2a526846be501bf8, type: 3}
     <icon>k__BackingField: {fileID: 0}
-  - <Name>k__BackingField: GrilledBeefNVeg
+  - <name>k__BackingField: GrilledBeefNVeg
     <food>k__BackingField: 68
     <tag>k__BackingField: 1
-    <ID>k__BackingField: 23
+    <id>k__BackingField: 104
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
-    <Prefab>k__BackingField: {fileID: 3349099462871534991, guid: b6ddc8ffa634b4c0b99bf9a89b160a58, type: 3}
+    <prefab>k__BackingField: {fileID: 3349099462871534991, guid: b6ddc8ffa634b4c0b99bf9a89b160a58, type: 3}
     <icon>k__BackingField: {fileID: 0}
-  - <Name>k__BackingField: GrilledMackerel
+  - <name>k__BackingField: GrilledSaba
     <food>k__BackingField: 83
     <tag>k__BackingField: 1
-    <ID>k__BackingField: 24
+    <id>k__BackingField: 105
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
-    <Prefab>k__BackingField: {fileID: 1895120071186820260, guid: d4706ce4f959b4dc4a20b75584d0767e, type: 3}
+    <prefab>k__BackingField: {fileID: 1895120071186820260, guid: d4706ce4f959b4dc4a20b75584d0767e, type: 3}
     <icon>k__BackingField: {fileID: 0}
-  - <Name>k__BackingField: GrilledBeef
+  - <name>k__BackingField: GrilledBeef
     <food>k__BackingField: 70
     <tag>k__BackingField: 1
-    <ID>k__BackingField: 25
+    <id>k__BackingField: 106
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
-    <Prefab>k__BackingField: {fileID: 5994628728736546187, guid: 8e037ae0c80b8424893f20f3b1a88135, type: 3}
+    <prefab>k__BackingField: {fileID: 5994628728736546187, guid: 8e037ae0c80b8424893f20f3b1a88135, type: 3}
     <icon>k__BackingField: {fileID: 0}
-  - <Name>k__BackingField: GrilledEel
-    <food>k__BackingField: 0
+  - <name>k__BackingField: GrilledUnagi
+    <food>k__BackingField: 76
     <tag>k__BackingField: 1
-    <ID>k__BackingField: 26
+    <id>k__BackingField: 107
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
-    <Prefab>k__BackingField: {fileID: 4147544906032101272, guid: a8107ac99399f40a5b7d68b2693063ad, type: 3}
+    <prefab>k__BackingField: {fileID: 4147544906032101272, guid: a8107ac99399f40a5b7d68b2693063ad, type: 3}
     <icon>k__BackingField: {fileID: 0}
-  - <Name>k__BackingField: GrilledPork
+  - <name>k__BackingField: GrilledPork
     <food>k__BackingField: 79
     <tag>k__BackingField: 1
-    <ID>k__BackingField: 27
+    <id>k__BackingField: 108
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
-    <Prefab>k__BackingField: {fileID: 7772951563969828875, guid: f84e72e3410f84a3eb9813d497400192, type: 3}
+    <prefab>k__BackingField: {fileID: 7772951563969828875, guid: f84e72e3410f84a3eb9813d497400192, type: 3}
     <icon>k__BackingField: {fileID: 0}
-  - <Name>k__BackingField: GrilledSalmon
+  - <name>k__BackingField: GrilledSalmon
     <food>k__BackingField: 74
     <tag>k__BackingField: 1
-    <ID>k__BackingField: 28
+    <id>k__BackingField: 109
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
-    <Prefab>k__BackingField: {fileID: 2670225449858919766, guid: 02f2a6ae354274ccbbdc3cffbea8702b, type: 3}
+    <prefab>k__BackingField: {fileID: 2670225449858919766, guid: 02f2a6ae354274ccbbdc3cffbea8702b, type: 3}
     <icon>k__BackingField: {fileID: 0}
-  - <Name>k__BackingField: GrilledShrimp
+  - <name>k__BackingField: GrilledShrimp
     <food>k__BackingField: 66
     <tag>k__BackingField: 1
-    <ID>k__BackingField: 29
+    <id>k__BackingField: 110
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
-    <Prefab>k__BackingField: {fileID: 4280993578947105436, guid: 9f147ac004d2f4c768096ab838075354, type: 3}
+    <prefab>k__BackingField: {fileID: 4280993578947105436, guid: 9f147ac004d2f4c768096ab838075354, type: 3}
     <icon>k__BackingField: {fileID: 0}
-  - <Name>k__BackingField: PiecedSalmon
+  - <name>k__BackingField: PiecedSalmon
     <food>k__BackingField: 73
     <tag>k__BackingField: 1
-    <ID>k__BackingField: 30
+    <id>k__BackingField: 111
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
-    <Prefab>k__BackingField: {fileID: 9217147774225242882, guid: 0412937935b17459396673469db2e6f8, type: 3}
+    <prefab>k__BackingField: {fileID: 9217147774225242882, guid: 0412937935b17459396673469db2e6f8, type: 3}
     <icon>k__BackingField: {fileID: 0}
-  - <Name>k__BackingField: PorkCutlet
+  - <name>k__BackingField: PorkCutlet
     <food>k__BackingField: 81
     <tag>k__BackingField: 1
-    <ID>k__BackingField: 31
+    <id>k__BackingField: 112
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
-    <Prefab>k__BackingField: {fileID: 5820098932443901850, guid: bca609429f70b4caab2f5b6497b833e1, type: 3}
+    <prefab>k__BackingField: {fileID: 5820098932443901850, guid: bca609429f70b4caab2f5b6497b833e1, type: 3}
     <icon>k__BackingField: {fileID: 0}
-  - <Name>k__BackingField: RamenSoupBowl
+  - <name>k__BackingField: RamenSoup
     <food>k__BackingField: 59
     <tag>k__BackingField: 1
-    <ID>k__BackingField: 32
+    <id>k__BackingField: 113
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
-    <Prefab>k__BackingField: {fileID: 4586437712627807600, guid: d3580d2d6c5e64a32aca28024d7250de, type: 3}
+    <prefab>k__BackingField: {fileID: 2760817210610945848, guid: eefccbc40764c4c83b6a535218eae056, type: 3}
     <icon>k__BackingField: {fileID: 0}
-  - <Name>k__BackingField: RamenSoup
-    <food>k__BackingField: 59
+  - <name>k__BackingField: RawBeef
+    <food>k__BackingField: 69
     <tag>k__BackingField: 1
-    <ID>k__BackingField: 33
+    <id>k__BackingField: 114
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
-    <Prefab>k__BackingField: {fileID: 2760817210610945848, guid: eefccbc40764c4c83b6a535218eae056, type: 3}
+    <prefab>k__BackingField: {fileID: 6586992115549774392, guid: b7584b71b1450496988917ccc9e6899e, type: 3}
     <icon>k__BackingField: {fileID: 0}
-  - <Name>k__BackingField: RawBeef
-    <food>k__BackingField: 0
-    <tag>k__BackingField: 1
-    <ID>k__BackingField: 34
-    <price>k__BackingField: 1000
-    <level>k__BackingField: 1
-    <Prefab>k__BackingField: {fileID: 6586992115549774392, guid: b7584b71b1450496988917ccc9e6899e, type: 3}
-    <icon>k__BackingField: {fileID: 0}
-  - <Name>k__BackingField: TrimmedBeef
+  - <name>k__BackingField: TrimmedBeef
     <food>k__BackingField: 68
     <tag>k__BackingField: 1
-    <ID>k__BackingField: 35
+    <id>k__BackingField: 115
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
-    <Prefab>k__BackingField: {fileID: 4414265435317524576, guid: be99d6ffae8074d40b4e47737d197e9a, type: 3}
+    <prefab>k__BackingField: {fileID: 4414265435317524576, guid: be99d6ffae8074d40b4e47737d197e9a, type: 3}
     <icon>k__BackingField: {fileID: 0}
-  - <Name>k__BackingField: TrimmedEel
+  - <name>k__BackingField: TrimmedUnagi
+    <food>k__BackingField: 75
+    <tag>k__BackingField: 1
+    <id>k__BackingField: 116
+    <price>k__BackingField: 1000
+    <level>k__BackingField: 1
+    <prefab>k__BackingField: {fileID: 3498816469846616115, guid: 58df8d258db56494eb1c321a386c5dea, type: 3}
+    <icon>k__BackingField: {fileID: 0}
+  - <name>k__BackingField: TrimmedFlatfish
     <food>k__BackingField: 64
     <tag>k__BackingField: 1
-    <ID>k__BackingField: 36
+    <id>k__BackingField: 117
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
-    <Prefab>k__BackingField: {fileID: 3498816469846616115, guid: 58df8d258db56494eb1c321a386c5dea, type: 3}
+    <prefab>k__BackingField: {fileID: 5493475046638010204, guid: 05eb6715566914e25ae805129b6d60f0, type: 3}
     <icon>k__BackingField: {fileID: 0}
-  - <Name>k__BackingField: TrimmedFlatfish
-    <food>k__BackingField: 64
-    <tag>k__BackingField: 1
-    <ID>k__BackingField: 37
-    <price>k__BackingField: 1000
-    <level>k__BackingField: 1
-    <Prefab>k__BackingField: {fileID: 5493475046638010204, guid: 05eb6715566914e25ae805129b6d60f0, type: 3}
-    <icon>k__BackingField: {fileID: 0}
-  - <Name>k__BackingField: TrimmedPork
+  - <name>k__BackingField: TrimmedPork
     <food>k__BackingField: 78
     <tag>k__BackingField: 1
-    <ID>k__BackingField: 38
+    <id>k__BackingField: 118
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
-    <Prefab>k__BackingField: {fileID: 6172634807142451179, guid: 1f74ca87327464b639345dd3304fca7d, type: 3}
+    <prefab>k__BackingField: {fileID: 6172634807142451179, guid: 1f74ca87327464b639345dd3304fca7d, type: 3}
     <icon>k__BackingField: {fileID: 0}
-  - <Name>k__BackingField: TrimmedSaba
+  - <name>k__BackingField: TrimmedSaba
     <food>k__BackingField: 67
     <tag>k__BackingField: 1
-    <ID>k__BackingField: 39
+    <id>k__BackingField: 119
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
-    <Prefab>k__BackingField: {fileID: 5383931453605002147, guid: e8a4ed008a7e5451c8aa3e4e660a2d85, type: 3}
+    <prefab>k__BackingField: {fileID: 5383931453605002147, guid: e8a4ed008a7e5451c8aa3e4e660a2d85, type: 3}
     <icon>k__BackingField: {fileID: 0}
-  - <Name>k__BackingField: TrimmedSalmon
+  - <name>k__BackingField: TrimmedSalmon
     <food>k__BackingField: 72
     <tag>k__BackingField: 1
-    <ID>k__BackingField: 40
+    <id>k__BackingField: 120
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
-    <Prefab>k__BackingField: {fileID: 9193149628080068938, guid: 03d175065f7b244b9b14bbf2c21e1e98, type: 3}
+    <prefab>k__BackingField: {fileID: 9193149628080068938, guid: 03d175065f7b244b9b14bbf2c21e1e98, type: 3}
     <icon>k__BackingField: {fileID: 0}
-  - <Name>k__BackingField: TrimmedShrimp
+  - <name>k__BackingField: TrimmedShrimp
     <food>k__BackingField: 65
     <tag>k__BackingField: 1
-    <ID>k__BackingField: 41
+    <id>k__BackingField: 121
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
-    <Prefab>k__BackingField: {fileID: 778079195131482413, guid: 33ea1cfb6761144d4b896578baad2dd5, type: 3}
+    <prefab>k__BackingField: {fileID: 778079195131482413, guid: 33ea1cfb6761144d4b896578baad2dd5, type: 3}
     <icon>k__BackingField: {fileID: 0}
-  - <Name>k__BackingField: TrimmedTofu
+  - <name>k__BackingField: TrimmedTofu
     <food>k__BackingField: 84
     <tag>k__BackingField: 1
-    <ID>k__BackingField: 42
+    <id>k__BackingField: 122
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
-    <Prefab>k__BackingField: {fileID: 8844105939027407574, guid: 6bc72b6cccef14513bfe1c0f6e5db135, type: 3}
+    <prefab>k__BackingField: {fileID: 8844105939027407574, guid: 6bc72b6cccef14513bfe1c0f6e5db135, type: 3}
     <icon>k__BackingField: {fileID: 0}
-  - <Name>k__BackingField: TrimmedTunaAkami
+  - <name>k__BackingField: TrimmedTunaAkami
     <food>k__BackingField: 71
     <tag>k__BackingField: 1
-    <ID>k__BackingField: 43
+    <id>k__BackingField: 123
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
-    <Prefab>k__BackingField: {fileID: 1479845603273236116, guid: b079cd47e1f5640dca0f50616ed49893, type: 3}
+    <prefab>k__BackingField: {fileID: 1479845603273236116, guid: b079cd47e1f5640dca0f50616ed49893, type: 3}
     <icon>k__BackingField: {fileID: 0}
-  - <Name>k__BackingField: TrimmedTunaDoro
+  - <name>k__BackingField: TrimmedTunaDoro
     <food>k__BackingField: 77
     <tag>k__BackingField: 1
-    <ID>k__BackingField: 44
+    <id>k__BackingField: 124
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
-    <Prefab>k__BackingField: {fileID: 4314160130475415669, guid: 69e507e9c2083464cb77d25446c43c06, type: 3}
+    <prefab>k__BackingField: {fileID: 4314160130475415669, guid: 69e507e9c2083464cb77d25446c43c06, type: 3}
     <icon>k__BackingField: {fileID: 0}
-  - <Name>k__BackingField: TrimmedVeg
+  - <name>k__BackingField: TrimmedVeg
     <food>k__BackingField: 82
     <tag>k__BackingField: 1
-    <ID>k__BackingField: 45
+    <id>k__BackingField: 125
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
-    <Prefab>k__BackingField: {fileID: 5003013232451133471, guid: ee5f1750a593043ae973f15a8222dad3, type: 3}
+    <prefab>k__BackingField: {fileID: 5003013232451133471, guid: ee5f1750a593043ae973f15a8222dad3, type: 3}
     <icon>k__BackingField: {fileID: 0}
-  - <Name>k__BackingField: EggSushi
+  - <name>k__BackingField: EggSushi
     <food>k__BackingField: 21
     <tag>k__BackingField: 2
-    <ID>k__BackingField: 46
+    <id>k__BackingField: 200
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
-    <Prefab>k__BackingField: {fileID: 524390802597008268, guid: 338b3998119ca489fa89d1b2329bb19b, type: 3}
+    <prefab>k__BackingField: {fileID: 524390802597008268, guid: 338b3998119ca489fa89d1b2329bb19b, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: 85e4d9ad6154e4458b2ca750604dcaac, type: 3}
-  - <Name>k__BackingField: FriedTofuSushi
+  - <name>k__BackingField: FriedTofuSushi
     <food>k__BackingField: 22
     <tag>k__BackingField: 2
-    <ID>k__BackingField: 47
+    <id>k__BackingField: 201
     <price>k__BackingField: 1000
     <level>k__BackingField: 2
-    <Prefab>k__BackingField: {fileID: 1819758596141938398, guid: b839b4948b302440ab4b438124c5ea2b, type: 3}
+    <prefab>k__BackingField: {fileID: 1819758596141938398, guid: b839b4948b302440ab4b438124c5ea2b, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: cb3045282841e45e1aa5fdff05ad0003, type: 3}
-  - <Name>k__BackingField: MackerelSushi
+  - <name>k__BackingField: MackerelSushi
     <food>k__BackingField: 25
     <tag>k__BackingField: 2
-    <ID>k__BackingField: 48
+    <id>k__BackingField: 202
     <price>k__BackingField: 1000
     <level>k__BackingField: 2
-    <Prefab>k__BackingField: {fileID: 8831638701008892303, guid: 6fb69d8b26f704aa8bb1846a6365a7c7, type: 3}
+    <prefab>k__BackingField: {fileID: 8831638701008892303, guid: 6fb69d8b26f704aa8bb1846a6365a7c7, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: d921233d5588e4559b674e7a03558fa4, type: 3}
-  - <Name>k__BackingField: FlatfishSushi
+  - <name>k__BackingField: FlatfishSushi
     <food>k__BackingField: 23
     <tag>k__BackingField: 2
-    <ID>k__BackingField: 49
+    <id>k__BackingField: 203
     <price>k__BackingField: 1000
     <level>k__BackingField: 3
-    <Prefab>k__BackingField: {fileID: 2223276481628621662, guid: 72449f23490674ae2a30e075ca38b594, type: 3}
+    <prefab>k__BackingField: {fileID: 2223276481628621662, guid: 72449f23490674ae2a30e075ca38b594, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: ea603508e932c46f1b021aae94aa0d14, type: 3}
-  - <Name>k__BackingField: ShrimpSushi
+  - <name>k__BackingField: ShrimpSushi
     <food>k__BackingField: 24
     <tag>k__BackingField: 2
-    <ID>k__BackingField: 50
+    <id>k__BackingField: 204
     <price>k__BackingField: 1000
     <level>k__BackingField: 3
-    <Prefab>k__BackingField: {fileID: 2993517041642147389, guid: 71d8b82d15c0649129e3746152160a33, type: 3}
+    <prefab>k__BackingField: {fileID: 2993517041642147389, guid: 71d8b82d15c0649129e3746152160a33, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: 1a0e0b9d44ee04bb78058f11c6d1fe2e, type: 3}
-  - <Name>k__BackingField: BeefSushi
+  - <name>k__BackingField: BeefSushi
     <food>k__BackingField: 26
     <tag>k__BackingField: 2
-    <ID>k__BackingField: 51
+    <id>k__BackingField: 205
     <price>k__BackingField: 1000
     <level>k__BackingField: 4
-    <Prefab>k__BackingField: {fileID: 2169001374624953386, guid: af48213ec5bab4cadbbd684c51a90d1c, type: 3}
+    <prefab>k__BackingField: {fileID: 2169001374624953386, guid: af48213ec5bab4cadbbd684c51a90d1c, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: 38f9794ecc6cc4e5c98ee283f3b46671, type: 3}
-  - <Name>k__BackingField: SalmonSushi
+  - <name>k__BackingField: SalmonSushi
     <food>k__BackingField: 28
     <tag>k__BackingField: 2
-    <ID>k__BackingField: 52
+    <id>k__BackingField: 206
     <price>k__BackingField: 1000
     <level>k__BackingField: 4
-    <Prefab>k__BackingField: {fileID: 5615254719090856724, guid: d0f0e4aa522ed4f35b75e0c6d3f9915b, type: 3}
+    <prefab>k__BackingField: {fileID: 5615254719090856724, guid: d0f0e4aa522ed4f35b75e0c6d3f9915b, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: 8c4afa6d834b34f2bb1259ca3ea83321, type: 3}
-  - <Name>k__BackingField: TunaAkamiSushi
+  - <name>k__BackingField: TunaAkamiSushi
     <food>k__BackingField: 27
     <tag>k__BackingField: 2
-    <ID>k__BackingField: 53
+    <id>k__BackingField: 207
     <price>k__BackingField: 1000
     <level>k__BackingField: 5
-    <Prefab>k__BackingField: {fileID: 8142243786085134417, guid: 72de3eaf62a974135aa1cf8e912de165, type: 3}
+    <prefab>k__BackingField: {fileID: 8142243786085134417, guid: 72de3eaf62a974135aa1cf8e912de165, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: 6beede8415f894047bf48bf7547c480a, type: 3}
-  - <Name>k__BackingField: SmokedSalmonSushi
+  - <name>k__BackingField: SmokedSalmonSushi
     <food>k__BackingField: 29
     <tag>k__BackingField: 2
-    <ID>k__BackingField: 54
+    <id>k__BackingField: 208
     <price>k__BackingField: 1000
     <level>k__BackingField: 6
-    <Prefab>k__BackingField: {fileID: 2646821394788172715, guid: a1aa0226930c140629344addea6db018, type: 3}
+    <prefab>k__BackingField: {fileID: 2646821394788172715, guid: a1aa0226930c140629344addea6db018, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: 6420e0a9b653843419101e1bc3bf4ae2, type: 3}
-  - <Name>k__BackingField: UnagiSushi
+  - <name>k__BackingField: UnagiSushi
     <food>k__BackingField: 30
     <tag>k__BackingField: 2
-    <ID>k__BackingField: 55
+    <id>k__BackingField: 209
     <price>k__BackingField: 1000
     <level>k__BackingField: 7
-    <Prefab>k__BackingField: {fileID: 3002752885237273843, guid: 0cf458fababce4902affa1108040bf87, type: 3}
+    <prefab>k__BackingField: {fileID: 3002752885237273843, guid: 0cf458fababce4902affa1108040bf87, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: 3468b5fa3f8a242f182057774f8b6976, type: 3}
-  - <Name>k__BackingField: TunaDoroSushi
+  - <name>k__BackingField: TunaDoroSushi
     <food>k__BackingField: 31
     <tag>k__BackingField: 2
-    <ID>k__BackingField: 56
+    <id>k__BackingField: 210
     <price>k__BackingField: 1000
     <level>k__BackingField: 8
-    <Prefab>k__BackingField: {fileID: 8753923425398735485, guid: 788b064da0fb74f1ab0ec714964a7807, type: 3}
+    <prefab>k__BackingField: {fileID: 8753923425398735485, guid: 788b064da0fb74f1ab0ec714964a7807, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: e9ba11409babe44a0923d023ac420661, type: 3}
-  - <Name>k__BackingField: ShoyuRamen
+  - <name>k__BackingField: ShoyuRamen
     <food>k__BackingField: 33
     <tag>k__BackingField: 2
-    <ID>k__BackingField: 57
+    <id>k__BackingField: 211
     <price>k__BackingField: 1000
     <level>k__BackingField: 3
-    <Prefab>k__BackingField: {fileID: 902126896480971816, guid: d0c5893ec54f14775bd5a01615d9d532, type: 3}
+    <prefab>k__BackingField: {fileID: 902126896480971816, guid: d0c5893ec54f14775bd5a01615d9d532, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: 52015edecceea4ef1864e6fa5eb8f42c, type: 3}
-  - <Name>k__BackingField: MisoRamen
+  - <name>k__BackingField: MisoRamen
     <food>k__BackingField: 34
     <tag>k__BackingField: 2
-    <ID>k__BackingField: 58
+    <id>k__BackingField: 212
     <price>k__BackingField: 1000
     <level>k__BackingField: 4
-    <Prefab>k__BackingField: {fileID: 9158517177999279118, guid: 22bc28f2b4fe440929112704b8237ff1, type: 3}
+    <prefab>k__BackingField: {fileID: 9158517177999279118, guid: 22bc28f2b4fe440929112704b8237ff1, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: 20fae8387345844a7bededcd296e209f, type: 3}
-  - <Name>k__BackingField: AburaRamen
+  - <name>k__BackingField: AburaRamen
     <food>k__BackingField: 35
     <tag>k__BackingField: 2
-    <ID>k__BackingField: 59
+    <id>k__BackingField: 213
     <price>k__BackingField: 1000
     <level>k__BackingField: 5
-    <Prefab>k__BackingField: {fileID: 1104107637635105722, guid: b970f7c5df49f4dbd9b8449d2b44b291, type: 3}
+    <prefab>k__BackingField: {fileID: 1104107637635105722, guid: b970f7c5df49f4dbd9b8449d2b44b291, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: e1409954405114de9b01823b6ef16543, type: 3}
-  - <Name>k__BackingField: TonkotsuRamen
+  - <name>k__BackingField: TonkotsuRamen
     <food>k__BackingField: 36
     <tag>k__BackingField: 2
-    <ID>k__BackingField: 60
+    <id>k__BackingField: 214
     <price>k__BackingField: 1000
     <level>k__BackingField: 6
-    <Prefab>k__BackingField: {fileID: 1420641156885054508, guid: 6854c51f22f4842708801f1710a737cc, type: 3}
+    <prefab>k__BackingField: {fileID: 1420641156885054508, guid: 6854c51f22f4842708801f1710a737cc, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: 3e29d1747b0344def982e68bc7041878, type: 3}
-  - <Name>k__BackingField: Tsukemen
+  - <name>k__BackingField: Tsukemen
     <food>k__BackingField: 37
     <tag>k__BackingField: 2
-    <ID>k__BackingField: 61
+    <id>k__BackingField: 215
     <price>k__BackingField: 1000
     <level>k__BackingField: 8
-    <Prefab>k__BackingField: {fileID: 872270813898845561, guid: b6e4916fe37e245cda7121c10929b800, type: 3}
-    <icon>k__BackingField: {fileID: 2800000, guid: 3e29d1747b0344def982e68bc7041878, type: 3}
-  - <Name>k__BackingField: ShrimpTempura
+    <prefab>k__BackingField: {fileID: 872270813898845561, guid: b6e4916fe37e245cda7121c10929b800, type: 3}
+    <icon>k__BackingField: {fileID: 2800000, guid: 7ff9b3353c3e04ae1ad9ae60983bba1c, type: 3}
+  - <name>k__BackingField: ShrimpTempura
     <food>k__BackingField: 38
     <tag>k__BackingField: 2
-    <ID>k__BackingField: 62
+    <id>k__BackingField: 216
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
-    <Prefab>k__BackingField: {fileID: 3017459830948678046, guid: 6337281bf49984da89e33e7d0bd52f7c, type: 3}
+    <prefab>k__BackingField: {fileID: 3017459830948678046, guid: 6337281bf49984da89e33e7d0bd52f7c, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: 1fc5f67f37af24cf1930da1322b9cafd, type: 3}
-  - <Name>k__BackingField: Tonkatsu
+  - <name>k__BackingField: Tonkatsu
     <food>k__BackingField: 39
     <tag>k__BackingField: 2
-    <ID>k__BackingField: 63
+    <id>k__BackingField: 217
     <price>k__BackingField: 1000
     <level>k__BackingField: 4
-    <Prefab>k__BackingField: {fileID: 172488309569222193, guid: 4ff23f9fbae5647e6ae66d24545b3f52, type: 3}
+    <prefab>k__BackingField: {fileID: 172488309569222193, guid: 4ff23f9fbae5647e6ae66d24545b3f52, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: 3cafd3be1ef4749ee82b1f9d792f0657, type: 3}
-  - <Name>k__BackingField: Hambagu
+  - <name>k__BackingField: Hambagu
     <food>k__BackingField: 42
     <tag>k__BackingField: 2
-    <ID>k__BackingField: 64
+    <id>k__BackingField: 218
     <price>k__BackingField: 1000
     <level>k__BackingField: 3
-    <Prefab>k__BackingField: {fileID: 2178350901961344293, guid: 1501bd6e82e294902a7c1755d1e86aad, type: 3}
+    <prefab>k__BackingField: {fileID: 2178350901961344293, guid: 1501bd6e82e294902a7c1755d1e86aad, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: 5e4fec4ef8a4f427ea1d6e65f8cf86f6, type: 3}
-  - <Name>k__BackingField: Chashu
+  - <name>k__BackingField: Chashu
     <food>k__BackingField: 45
     <tag>k__BackingField: 2
-    <ID>k__BackingField: 65
+    <id>k__BackingField: 219
     <price>k__BackingField: 1000
     <level>k__BackingField: 5
-    <Prefab>k__BackingField: {fileID: 7102521602351250888, guid: 3649158f6949d40609671702b778485a, type: 3}
+    <prefab>k__BackingField: {fileID: 7102521602351250888, guid: 3649158f6949d40609671702b778485a, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: 9e1389df3f003471a9243df19b39f783, type: 3}
-  - <Name>k__BackingField: SalmonSteak
+  - <name>k__BackingField: SalmonSteak
     <food>k__BackingField: 43
     <tag>k__BackingField: 1
-    <ID>k__BackingField: 66
+    <id>k__BackingField: 220
     <price>k__BackingField: 1000
     <level>k__BackingField: 6
-    <Prefab>k__BackingField: {fileID: 8323801601026510530, guid: e1534ee326cae4241b1b474c7c51eece, type: 3}
+    <prefab>k__BackingField: {fileID: 8323801601026510530, guid: e1534ee326cae4241b1b474c7c51eece, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: 26e3a318f51bf4417a89f759c58482b9, type: 3}
-  - <Name>k__BackingField: WagyuSteak
+  - <name>k__BackingField: WagyuSteak
     <food>k__BackingField: 44
     <tag>k__BackingField: 2
-    <ID>k__BackingField: 67
+    <id>k__BackingField: 221
     <price>k__BackingField: 1000
     <level>k__BackingField: 6
-    <Prefab>k__BackingField: {fileID: 879789162398072225, guid: 4a3a76ff468d44b37944b1c0a2d127b5, type: 3}
+    <prefab>k__BackingField: {fileID: 879789162398072225, guid: 4a3a76ff468d44b37944b1c0a2d127b5, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: df97c4260b92a4362afe66d8cb73b1de, type: 3}
-  - <Name>k__BackingField: Onigiri
+  - <name>k__BackingField: Onigiri
     <food>k__BackingField: 46
     <tag>k__BackingField: 2
-    <ID>k__BackingField: 68
+    <id>k__BackingField: 222
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
-    <Prefab>k__BackingField: {fileID: 7456672238198072862, guid: 4bcd99c1e706a4a2e81bd1ad51e29232, type: 3}
+    <prefab>k__BackingField: {fileID: 7456672238198072862, guid: 4bcd99c1e706a4a2e81bd1ad51e29232, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: ddbfb772a1cdb4106aa7ada276d7acee, type: 3}
-  - <Name>k__BackingField: EbiTendon
+  - <name>k__BackingField: EbiTendon
     <food>k__BackingField: 47
     <tag>k__BackingField: 2
-    <ID>k__BackingField: 69
+    <id>k__BackingField: 223
     <price>k__BackingField: 1000
     <level>k__BackingField: 2
-    <Prefab>k__BackingField: {fileID: 4544470703169832204, guid: 565efd4474394422c90425c0fbcb1ccd, type: 3}
+    <prefab>k__BackingField: {fileID: 4544470703169832204, guid: 565efd4474394422c90425c0fbcb1ccd, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: f19f04a644b954a429b548e18506771c, type: 3}
-  - <Name>k__BackingField: SabaDon
+  - <name>k__BackingField: SabaDon
     <food>k__BackingField: 48
     <tag>k__BackingField: 2
-    <ID>k__BackingField: 70
+    <id>k__BackingField: 224
     <price>k__BackingField: 1000
     <level>k__BackingField: 3
-    <Prefab>k__BackingField: {fileID: 5238755672133759669, guid: 091b1ba286ad14c1f9cd95677ee671d5, type: 3}
+    <prefab>k__BackingField: {fileID: 5238755672133759669, guid: 091b1ba286ad14c1f9cd95677ee671d5, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: 618143385e71e4ca8ac51da15a5ed1de, type: 3}
-  - <Name>k__BackingField: Gyudon
+  - <name>k__BackingField: Gyudon
     <food>k__BackingField: 49
     <tag>k__BackingField: 2
-    <ID>k__BackingField: 71
+    <id>k__BackingField: 225
     <price>k__BackingField: 1000
     <level>k__BackingField: 4
-    <Prefab>k__BackingField: {fileID: 719273078047477409, guid: 6d6bc45fadd8c439592eb44a4708f2de, type: 3}
+    <prefab>k__BackingField: {fileID: 719273078047477409, guid: 6d6bc45fadd8c439592eb44a4708f2de, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: ed36d8791c6704aa0ada807759c7abb0, type: 3}
-  - <Name>k__BackingField: Sakedon
+  - <name>k__BackingField: Sakedon
     <food>k__BackingField: 50
     <tag>k__BackingField: 2
-    <ID>k__BackingField: 72
+    <id>k__BackingField: 226
     <price>k__BackingField: 1000
     <level>k__BackingField: 5
-    <Prefab>k__BackingField: {fileID: 7301623037957447432, guid: 45740cd4b46a341c88f560035e2d5647, type: 3}
+    <prefab>k__BackingField: {fileID: 7301623037957447432, guid: 45740cd4b46a341c88f560035e2d5647, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: fdc3de05dbf574997920874d3c366493, type: 3}
-  - <Name>k__BackingField: Chashudon
+  - <name>k__BackingField: Chashudon
     <food>k__BackingField: 51
     <tag>k__BackingField: 2
-    <ID>k__BackingField: 73
+    <id>k__BackingField: 227
     <price>k__BackingField: 1000
     <level>k__BackingField: 6
-    <Prefab>k__BackingField: {fileID: 3654126326403113629, guid: 1d915630fc4644b8db16c7feb8e3d2d9, type: 3}
+    <prefab>k__BackingField: {fileID: 3654126326403113629, guid: 1d915630fc4644b8db16c7feb8e3d2d9, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: 5c6362ca5b613423a9f5d6c54a58b4ca, type: 3}
-  - <Name>k__BackingField: SalmonSteakdon
+  - <name>k__BackingField: SalmonSteakdon
     <food>k__BackingField: 52
     <tag>k__BackingField: 2
-    <ID>k__BackingField: 74
+    <id>k__BackingField: 228
     <price>k__BackingField: 1000
     <level>k__BackingField: 7
-    <Prefab>k__BackingField: {fileID: 577707678281493577, guid: 50f67e73aec6a4e1f86df179ca8a7435, type: 3}
+    <prefab>k__BackingField: {fileID: 577707678281493577, guid: 50f67e73aec6a4e1f86df179ca8a7435, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: 8fe216f1500eb4636acd9ee4909f3837, type: 3}
-  - <Name>k__BackingField: Unagidon
+  - <name>k__BackingField: Unagidon
     <food>k__BackingField: 53
     <tag>k__BackingField: 2
-    <ID>k__BackingField: 75
+    <id>k__BackingField: 229
     <price>k__BackingField: 1000
     <level>k__BackingField: 8
-    <Prefab>k__BackingField: {fileID: 4201431055077167541, guid: 59607a41e19e64e8f99077b4087ad8a1, type: 3}
+    <prefab>k__BackingField: {fileID: 4201431055077167541, guid: 59607a41e19e64e8f99077b4087ad8a1, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: 0e348608327d14d609f34a994a4f8817, type: 3}
-  - <Name>k__BackingField: MisoSoup
+  - <name>k__BackingField: MisoSoup
     <food>k__BackingField: 56
     <tag>k__BackingField: 2
-    <ID>k__BackingField: 76
+    <id>k__BackingField: 230
     <price>k__BackingField: 1000
     <level>k__BackingField: 4
-    <Prefab>k__BackingField: {fileID: 4117434976560213589, guid: 0398a3fe9d59b4d9ebb10be843eadf30, type: 3}
+    <prefab>k__BackingField: {fileID: 4117434976560213589, guid: 0398a3fe9d59b4d9ebb10be843eadf30, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: 078b1747f4f0a4578b49cb53db59b038, type: 3}
-  - <Name>k__BackingField: Tea
+  - <name>k__BackingField: Tea
     <food>k__BackingField: 57
     <tag>k__BackingField: 2
-    <ID>k__BackingField: 77
+    <id>k__BackingField: 231
     <price>k__BackingField: 1000
     <level>k__BackingField: 2
-    <Prefab>k__BackingField: {fileID: 2906252503343478693, guid: d8af5ff02e09a4025b5e4dd800f35a83, type: 3}
+    <prefab>k__BackingField: {fileID: 2906252503343478693, guid: d8af5ff02e09a4025b5e4dd800f35a83, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: b2ead2aec46ff4b0d8efd2628cbc3439, type: 3}

--- a/Assets/ScriptableObjects/FoodObjectSO/FoodDatabase.asset
+++ b/Assets/ScriptableObjects/FoodObjectSO/FoodDatabase.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   foodData:
   - <Name>k__BackingField: Water
-    <KoreanName>k__BackingField: 13
+    <food>k__BackingField: 13
     <tag>k__BackingField: 0
     <ID>k__BackingField: 1
     <price>k__BackingField: 1000
@@ -22,7 +22,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 7658888424487957560, guid: 858d6f087e4884a44828a9972ebd862c, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: 57c41c1f12c2445b2ba2dd9188b3d3d9, type: 3}
   - <Name>k__BackingField: Vinegar
-    <KoreanName>k__BackingField: 12
+    <food>k__BackingField: 12
     <tag>k__BackingField: 0
     <ID>k__BackingField: 2
     <price>k__BackingField: 1000
@@ -30,7 +30,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 7497115926558726248, guid: fdd184d5328a04b2d92528018c2a4579, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: ea81d37d2c27b47458683d2bf90822d8, type: 3}
   - <Name>k__BackingField: Soysauce
-    <KoreanName>k__BackingField: 15
+    <food>k__BackingField: 15
     <tag>k__BackingField: 0
     <ID>k__BackingField: 3
     <price>k__BackingField: 1000
@@ -38,7 +38,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 3202690755826013567, guid: 6795187f7503a4d59bec7eab34307513, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: 38277244fda184b3f9bf001bee1a912b, type: 3}
   - <Name>k__BackingField: Miso
-    <KoreanName>k__BackingField: 16
+    <food>k__BackingField: 16
     <tag>k__BackingField: 0
     <ID>k__BackingField: 4
     <price>k__BackingField: 1000
@@ -46,7 +46,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 3505866646548267482, guid: ae6fe198d936542298b80a2e4d2ecee8, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: be352e9356ef64e15bc73c86d3ac587a, type: 3}
   - <Name>k__BackingField: Rice
-    <KoreanName>k__BackingField: 0
+    <food>k__BackingField: 0
     <tag>k__BackingField: 0
     <ID>k__BackingField: 5
     <price>k__BackingField: 1000
@@ -54,7 +54,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 9083243063744714783, guid: dc7a29cfd1e3d423186054b30dede15b, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: 4ed82be0d8c3d45f1a9979a7ddca8537, type: 3}
   - <Name>k__BackingField: FryPowder
-    <KoreanName>k__BackingField: 17
+    <food>k__BackingField: 17
     <tag>k__BackingField: 0
     <ID>k__BackingField: 6
     <price>k__BackingField: 1000
@@ -62,7 +62,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 7658888424487957560, guid: 858d6f087e4884a44828a9972ebd862c, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: 6c93784436b1545bcb48efed094102c3, type: 3}
   - <Name>k__BackingField: Noodle
-    <KoreanName>k__BackingField: 14
+    <food>k__BackingField: 14
     <tag>k__BackingField: 0
     <ID>k__BackingField: 7
     <price>k__BackingField: 1000
@@ -70,7 +70,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 3067885276403880707, guid: 2e5c95145ab3842ac904f2aba75af068, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: 44fbece8093fc4361bd7815195eeddd5, type: 3}
   - <Name>k__BackingField: Tofu
-    <KoreanName>k__BackingField: 2
+    <food>k__BackingField: 2
     <tag>k__BackingField: 0
     <ID>k__BackingField: 8
     <price>k__BackingField: 1000
@@ -78,7 +78,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 2569467188940230205, guid: 62fe09e6fdfc348a5ae1c6a52f799241, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: 3042022ba4748422fbc4760a27398995, type: 3}
   - <Name>k__BackingField: Egg
-    <KoreanName>k__BackingField: 1
+    <food>k__BackingField: 1
     <tag>k__BackingField: 0
     <ID>k__BackingField: 9
     <price>k__BackingField: 1000
@@ -86,7 +86,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 8389371753922280744, guid: d2325c2c59a9444009c2bc43ac13061c, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: d51a4ac8e10bb49eb87772998006c838, type: 3}
   - <Name>k__BackingField: Pork
-    <KoreanName>k__BackingField: 11
+    <food>k__BackingField: 11
     <tag>k__BackingField: 0
     <ID>k__BackingField: 10
     <price>k__BackingField: 1000
@@ -94,7 +94,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 6881908385715226372, guid: 0b846b3416f4d412090b11f4bc22ab0f, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: ea8db274cc03b41928a6284e9ef5ae8e, type: 3}
   - <Name>k__BackingField: Beef
-    <KoreanName>k__BackingField: 6
+    <food>k__BackingField: 6
     <tag>k__BackingField: 0
     <ID>k__BackingField: 11
     <price>k__BackingField: 1000
@@ -102,7 +102,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 6274084391122988245, guid: 9eee2e4b908a24ffa889fc49be8cc8a6, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: 07456d10633e04d71853135c3bf52878, type: 3}
   - <Name>k__BackingField: Shrimp
-    <KoreanName>k__BackingField: 4
+    <food>k__BackingField: 4
     <tag>k__BackingField: 0
     <ID>k__BackingField: 12
     <price>k__BackingField: 1000
@@ -110,7 +110,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 2604253987008481563, guid: 872801591ea4445e59b45584beca57c6, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: 8f59dc0b9a3ee4c87bf5d4d3fcf59eb8, type: 3}
   - <Name>k__BackingField: Vegetable
-    <KoreanName>k__BackingField: 19
+    <food>k__BackingField: 19
     <tag>k__BackingField: 0
     <ID>k__BackingField: 13
     <price>k__BackingField: 1000
@@ -118,7 +118,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 1843141169661942814, guid: d278d01a1c3f6416f95c5c53eb3f1fdb, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: eb8bd001eadaa40eeb8010278dac92e0, type: 3}
   - <Name>k__BackingField: Flatfish
-    <KoreanName>k__BackingField: 3
+    <food>k__BackingField: 3
     <tag>k__BackingField: 0
     <ID>k__BackingField: 14
     <price>k__BackingField: 1000
@@ -126,7 +126,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 5773488423304670987, guid: a8fb2a1e56c1f41699379752eb62a4ce, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: a7ebe0897cc8b4fe9be4d6d94df071c2, type: 3}
   - <Name>k__BackingField: Saba
-    <KoreanName>k__BackingField: 5
+    <food>k__BackingField: 5
     <tag>k__BackingField: 0
     <ID>k__BackingField: 15
     <price>k__BackingField: 1000
@@ -134,7 +134,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 5773488423304670987, guid: a8fb2a1e56c1f41699379752eb62a4ce, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: a7ebe0897cc8b4fe9be4d6d94df071c2, type: 3}
   - <Name>k__BackingField: Tuna
-    <KoreanName>k__BackingField: 7
+    <food>k__BackingField: 7
     <tag>k__BackingField: 0
     <ID>k__BackingField: 16
     <price>k__BackingField: 1000
@@ -142,7 +142,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 5773488423304670987, guid: a8fb2a1e56c1f41699379752eb62a4ce, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: a7ebe0897cc8b4fe9be4d6d94df071c2, type: 3}
   - <Name>k__BackingField: Salmon
-    <KoreanName>k__BackingField: 9
+    <food>k__BackingField: 9
     <tag>k__BackingField: 0
     <ID>k__BackingField: 17
     <price>k__BackingField: 1000
@@ -150,7 +150,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 5773488423304670987, guid: a8fb2a1e56c1f41699379752eb62a4ce, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: a7ebe0897cc8b4fe9be4d6d94df071c2, type: 3}
   - <Name>k__BackingField: Unagi
-    <KoreanName>k__BackingField: 10
+    <food>k__BackingField: 10
     <tag>k__BackingField: 0
     <ID>k__BackingField: 18
     <price>k__BackingField: 1000
@@ -158,7 +158,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 5773488423304670987, guid: a8fb2a1e56c1f41699379752eb62a4ce, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: a7ebe0897cc8b4fe9be4d6d94df071c2, type: 3}
   - <Name>k__BackingField: CookedRicePot
-    <KoreanName>k__BackingField: 60
+    <food>k__BackingField: 60
     <tag>k__BackingField: 1
     <ID>k__BackingField: 19
     <price>k__BackingField: 1000
@@ -166,7 +166,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 7696103292884469837, guid: 6f5ea644a7dfd4694899f70d65628207, type: 3}
     <icon>k__BackingField: {fileID: 0}
   - <Name>k__BackingField: CookedRice
-    <KoreanName>k__BackingField: 58
+    <food>k__BackingField: 58
     <tag>k__BackingField: 1
     <ID>k__BackingField: 20
     <price>k__BackingField: 1000
@@ -174,7 +174,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 4323809633325535547, guid: d4c4c6549a0c14d58ba1fb9dce93a8d6, type: 3}
     <icon>k__BackingField: {fileID: 0}
   - <Name>k__BackingField: EggRoll
-    <KoreanName>k__BackingField: 61
+    <food>k__BackingField: 61
     <tag>k__BackingField: 1
     <ID>k__BackingField: 21
     <price>k__BackingField: 1000
@@ -182,7 +182,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 9032505915419756735, guid: 37906f56bca534bc49351cf1bb17ed10, type: 3}
     <icon>k__BackingField: {fileID: 0}
   - <Name>k__BackingField: FriedTofu
-    <KoreanName>k__BackingField: 63
+    <food>k__BackingField: 63
     <tag>k__BackingField: 1
     <ID>k__BackingField: 22
     <price>k__BackingField: 1000
@@ -190,7 +190,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 7153209375705375888, guid: db231e412588d46e2a526846be501bf8, type: 3}
     <icon>k__BackingField: {fileID: 0}
   - <Name>k__BackingField: GrilledBeefNVeg
-    <KoreanName>k__BackingField: 68
+    <food>k__BackingField: 68
     <tag>k__BackingField: 1
     <ID>k__BackingField: 23
     <price>k__BackingField: 1000
@@ -198,7 +198,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 3349099462871534991, guid: b6ddc8ffa634b4c0b99bf9a89b160a58, type: 3}
     <icon>k__BackingField: {fileID: 0}
   - <Name>k__BackingField: GrilledMackerel
-    <KoreanName>k__BackingField: 83
+    <food>k__BackingField: 83
     <tag>k__BackingField: 1
     <ID>k__BackingField: 24
     <price>k__BackingField: 1000
@@ -206,7 +206,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 1895120071186820260, guid: d4706ce4f959b4dc4a20b75584d0767e, type: 3}
     <icon>k__BackingField: {fileID: 0}
   - <Name>k__BackingField: GrilledBeef
-    <KoreanName>k__BackingField: 70
+    <food>k__BackingField: 70
     <tag>k__BackingField: 1
     <ID>k__BackingField: 25
     <price>k__BackingField: 1000
@@ -214,7 +214,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 5994628728736546187, guid: 8e037ae0c80b8424893f20f3b1a88135, type: 3}
     <icon>k__BackingField: {fileID: 0}
   - <Name>k__BackingField: GrilledEel
-    <KoreanName>k__BackingField: 0
+    <food>k__BackingField: 0
     <tag>k__BackingField: 1
     <ID>k__BackingField: 26
     <price>k__BackingField: 1000
@@ -222,7 +222,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 4147544906032101272, guid: a8107ac99399f40a5b7d68b2693063ad, type: 3}
     <icon>k__BackingField: {fileID: 0}
   - <Name>k__BackingField: GrilledPork
-    <KoreanName>k__BackingField: 79
+    <food>k__BackingField: 79
     <tag>k__BackingField: 1
     <ID>k__BackingField: 27
     <price>k__BackingField: 1000
@@ -230,7 +230,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 7772951563969828875, guid: f84e72e3410f84a3eb9813d497400192, type: 3}
     <icon>k__BackingField: {fileID: 0}
   - <Name>k__BackingField: GrilledSalmon
-    <KoreanName>k__BackingField: 74
+    <food>k__BackingField: 74
     <tag>k__BackingField: 1
     <ID>k__BackingField: 28
     <price>k__BackingField: 1000
@@ -238,7 +238,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 2670225449858919766, guid: 02f2a6ae354274ccbbdc3cffbea8702b, type: 3}
     <icon>k__BackingField: {fileID: 0}
   - <Name>k__BackingField: GrilledShrimp
-    <KoreanName>k__BackingField: 66
+    <food>k__BackingField: 66
     <tag>k__BackingField: 1
     <ID>k__BackingField: 29
     <price>k__BackingField: 1000
@@ -246,7 +246,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 4280993578947105436, guid: 9f147ac004d2f4c768096ab838075354, type: 3}
     <icon>k__BackingField: {fileID: 0}
   - <Name>k__BackingField: PiecedSalmon
-    <KoreanName>k__BackingField: 73
+    <food>k__BackingField: 73
     <tag>k__BackingField: 1
     <ID>k__BackingField: 30
     <price>k__BackingField: 1000
@@ -254,7 +254,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 9217147774225242882, guid: 0412937935b17459396673469db2e6f8, type: 3}
     <icon>k__BackingField: {fileID: 0}
   - <Name>k__BackingField: PorkCutlet
-    <KoreanName>k__BackingField: 81
+    <food>k__BackingField: 81
     <tag>k__BackingField: 1
     <ID>k__BackingField: 31
     <price>k__BackingField: 1000
@@ -262,7 +262,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 5820098932443901850, guid: bca609429f70b4caab2f5b6497b833e1, type: 3}
     <icon>k__BackingField: {fileID: 0}
   - <Name>k__BackingField: RamenSoupBowl
-    <KoreanName>k__BackingField: 59
+    <food>k__BackingField: 59
     <tag>k__BackingField: 1
     <ID>k__BackingField: 32
     <price>k__BackingField: 1000
@@ -270,7 +270,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 4586437712627807600, guid: d3580d2d6c5e64a32aca28024d7250de, type: 3}
     <icon>k__BackingField: {fileID: 0}
   - <Name>k__BackingField: RamenSoup
-    <KoreanName>k__BackingField: 59
+    <food>k__BackingField: 59
     <tag>k__BackingField: 1
     <ID>k__BackingField: 33
     <price>k__BackingField: 1000
@@ -278,7 +278,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 2760817210610945848, guid: eefccbc40764c4c83b6a535218eae056, type: 3}
     <icon>k__BackingField: {fileID: 0}
   - <Name>k__BackingField: RawBeef
-    <KoreanName>k__BackingField: 0
+    <food>k__BackingField: 0
     <tag>k__BackingField: 1
     <ID>k__BackingField: 34
     <price>k__BackingField: 1000
@@ -286,7 +286,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 6586992115549774392, guid: b7584b71b1450496988917ccc9e6899e, type: 3}
     <icon>k__BackingField: {fileID: 0}
   - <Name>k__BackingField: TrimmedBeef
-    <KoreanName>k__BackingField: 68
+    <food>k__BackingField: 68
     <tag>k__BackingField: 1
     <ID>k__BackingField: 35
     <price>k__BackingField: 1000
@@ -294,7 +294,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 4414265435317524576, guid: be99d6ffae8074d40b4e47737d197e9a, type: 3}
     <icon>k__BackingField: {fileID: 0}
   - <Name>k__BackingField: TrimmedEel
-    <KoreanName>k__BackingField: 64
+    <food>k__BackingField: 64
     <tag>k__BackingField: 1
     <ID>k__BackingField: 36
     <price>k__BackingField: 1000
@@ -302,7 +302,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 3498816469846616115, guid: 58df8d258db56494eb1c321a386c5dea, type: 3}
     <icon>k__BackingField: {fileID: 0}
   - <Name>k__BackingField: TrimmedFlatfish
-    <KoreanName>k__BackingField: 64
+    <food>k__BackingField: 64
     <tag>k__BackingField: 1
     <ID>k__BackingField: 37
     <price>k__BackingField: 1000
@@ -310,7 +310,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 5493475046638010204, guid: 05eb6715566914e25ae805129b6d60f0, type: 3}
     <icon>k__BackingField: {fileID: 0}
   - <Name>k__BackingField: TrimmedPork
-    <KoreanName>k__BackingField: 78
+    <food>k__BackingField: 78
     <tag>k__BackingField: 1
     <ID>k__BackingField: 38
     <price>k__BackingField: 1000
@@ -318,7 +318,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 6172634807142451179, guid: 1f74ca87327464b639345dd3304fca7d, type: 3}
     <icon>k__BackingField: {fileID: 0}
   - <Name>k__BackingField: TrimmedSaba
-    <KoreanName>k__BackingField: 67
+    <food>k__BackingField: 67
     <tag>k__BackingField: 1
     <ID>k__BackingField: 39
     <price>k__BackingField: 1000
@@ -326,7 +326,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 5383931453605002147, guid: e8a4ed008a7e5451c8aa3e4e660a2d85, type: 3}
     <icon>k__BackingField: {fileID: 0}
   - <Name>k__BackingField: TrimmedSalmon
-    <KoreanName>k__BackingField: 72
+    <food>k__BackingField: 72
     <tag>k__BackingField: 1
     <ID>k__BackingField: 40
     <price>k__BackingField: 1000
@@ -334,7 +334,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 9193149628080068938, guid: 03d175065f7b244b9b14bbf2c21e1e98, type: 3}
     <icon>k__BackingField: {fileID: 0}
   - <Name>k__BackingField: TrimmedShrimp
-    <KoreanName>k__BackingField: 65
+    <food>k__BackingField: 65
     <tag>k__BackingField: 1
     <ID>k__BackingField: 41
     <price>k__BackingField: 1000
@@ -342,7 +342,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 778079195131482413, guid: 33ea1cfb6761144d4b896578baad2dd5, type: 3}
     <icon>k__BackingField: {fileID: 0}
   - <Name>k__BackingField: TrimmedTofu
-    <KoreanName>k__BackingField: 84
+    <food>k__BackingField: 84
     <tag>k__BackingField: 1
     <ID>k__BackingField: 42
     <price>k__BackingField: 1000
@@ -350,7 +350,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 8844105939027407574, guid: 6bc72b6cccef14513bfe1c0f6e5db135, type: 3}
     <icon>k__BackingField: {fileID: 0}
   - <Name>k__BackingField: TrimmedTunaAkami
-    <KoreanName>k__BackingField: 71
+    <food>k__BackingField: 71
     <tag>k__BackingField: 1
     <ID>k__BackingField: 43
     <price>k__BackingField: 1000
@@ -358,7 +358,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 1479845603273236116, guid: b079cd47e1f5640dca0f50616ed49893, type: 3}
     <icon>k__BackingField: {fileID: 0}
   - <Name>k__BackingField: TrimmedTunaDoro
-    <KoreanName>k__BackingField: 77
+    <food>k__BackingField: 77
     <tag>k__BackingField: 1
     <ID>k__BackingField: 44
     <price>k__BackingField: 1000
@@ -366,7 +366,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 4314160130475415669, guid: 69e507e9c2083464cb77d25446c43c06, type: 3}
     <icon>k__BackingField: {fileID: 0}
   - <Name>k__BackingField: TrimmedVeg
-    <KoreanName>k__BackingField: 82
+    <food>k__BackingField: 82
     <tag>k__BackingField: 1
     <ID>k__BackingField: 45
     <price>k__BackingField: 1000
@@ -374,7 +374,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 5003013232451133471, guid: ee5f1750a593043ae973f15a8222dad3, type: 3}
     <icon>k__BackingField: {fileID: 0}
   - <Name>k__BackingField: EggSushi
-    <KoreanName>k__BackingField: 21
+    <food>k__BackingField: 21
     <tag>k__BackingField: 2
     <ID>k__BackingField: 46
     <price>k__BackingField: 1000
@@ -382,7 +382,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 524390802597008268, guid: 338b3998119ca489fa89d1b2329bb19b, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: 85e4d9ad6154e4458b2ca750604dcaac, type: 3}
   - <Name>k__BackingField: FriedTofuSushi
-    <KoreanName>k__BackingField: 22
+    <food>k__BackingField: 22
     <tag>k__BackingField: 2
     <ID>k__BackingField: 47
     <price>k__BackingField: 1000
@@ -390,7 +390,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 1819758596141938398, guid: b839b4948b302440ab4b438124c5ea2b, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: cb3045282841e45e1aa5fdff05ad0003, type: 3}
   - <Name>k__BackingField: MackerelSushi
-    <KoreanName>k__BackingField: 25
+    <food>k__BackingField: 25
     <tag>k__BackingField: 2
     <ID>k__BackingField: 48
     <price>k__BackingField: 1000
@@ -398,7 +398,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 8831638701008892303, guid: 6fb69d8b26f704aa8bb1846a6365a7c7, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: d921233d5588e4559b674e7a03558fa4, type: 3}
   - <Name>k__BackingField: FlatfishSushi
-    <KoreanName>k__BackingField: 23
+    <food>k__BackingField: 23
     <tag>k__BackingField: 2
     <ID>k__BackingField: 49
     <price>k__BackingField: 1000
@@ -406,7 +406,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 2223276481628621662, guid: 72449f23490674ae2a30e075ca38b594, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: ea603508e932c46f1b021aae94aa0d14, type: 3}
   - <Name>k__BackingField: ShrimpSushi
-    <KoreanName>k__BackingField: 24
+    <food>k__BackingField: 24
     <tag>k__BackingField: 2
     <ID>k__BackingField: 50
     <price>k__BackingField: 1000
@@ -414,7 +414,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 2993517041642147389, guid: 71d8b82d15c0649129e3746152160a33, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: 1a0e0b9d44ee04bb78058f11c6d1fe2e, type: 3}
   - <Name>k__BackingField: BeefSushi
-    <KoreanName>k__BackingField: 26
+    <food>k__BackingField: 26
     <tag>k__BackingField: 2
     <ID>k__BackingField: 51
     <price>k__BackingField: 1000
@@ -422,7 +422,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 2169001374624953386, guid: af48213ec5bab4cadbbd684c51a90d1c, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: 38f9794ecc6cc4e5c98ee283f3b46671, type: 3}
   - <Name>k__BackingField: SalmonSushi
-    <KoreanName>k__BackingField: 28
+    <food>k__BackingField: 28
     <tag>k__BackingField: 2
     <ID>k__BackingField: 52
     <price>k__BackingField: 1000
@@ -430,7 +430,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 5615254719090856724, guid: d0f0e4aa522ed4f35b75e0c6d3f9915b, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: 8c4afa6d834b34f2bb1259ca3ea83321, type: 3}
   - <Name>k__BackingField: TunaAkamiSushi
-    <KoreanName>k__BackingField: 27
+    <food>k__BackingField: 27
     <tag>k__BackingField: 2
     <ID>k__BackingField: 53
     <price>k__BackingField: 1000
@@ -438,7 +438,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 8142243786085134417, guid: 72de3eaf62a974135aa1cf8e912de165, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: 6beede8415f894047bf48bf7547c480a, type: 3}
   - <Name>k__BackingField: SmokedSalmonSushi
-    <KoreanName>k__BackingField: 29
+    <food>k__BackingField: 29
     <tag>k__BackingField: 2
     <ID>k__BackingField: 54
     <price>k__BackingField: 1000
@@ -446,7 +446,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 2646821394788172715, guid: a1aa0226930c140629344addea6db018, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: 6420e0a9b653843419101e1bc3bf4ae2, type: 3}
   - <Name>k__BackingField: UnagiSushi
-    <KoreanName>k__BackingField: 30
+    <food>k__BackingField: 30
     <tag>k__BackingField: 2
     <ID>k__BackingField: 55
     <price>k__BackingField: 1000
@@ -454,7 +454,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 3002752885237273843, guid: 0cf458fababce4902affa1108040bf87, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: 3468b5fa3f8a242f182057774f8b6976, type: 3}
   - <Name>k__BackingField: TunaDoroSushi
-    <KoreanName>k__BackingField: 31
+    <food>k__BackingField: 31
     <tag>k__BackingField: 2
     <ID>k__BackingField: 56
     <price>k__BackingField: 1000
@@ -462,7 +462,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 8753923425398735485, guid: 788b064da0fb74f1ab0ec714964a7807, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: e9ba11409babe44a0923d023ac420661, type: 3}
   - <Name>k__BackingField: ShoyuRamen
-    <KoreanName>k__BackingField: 33
+    <food>k__BackingField: 33
     <tag>k__BackingField: 2
     <ID>k__BackingField: 57
     <price>k__BackingField: 1000
@@ -470,7 +470,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 902126896480971816, guid: d0c5893ec54f14775bd5a01615d9d532, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: 52015edecceea4ef1864e6fa5eb8f42c, type: 3}
   - <Name>k__BackingField: MisoRamen
-    <KoreanName>k__BackingField: 34
+    <food>k__BackingField: 34
     <tag>k__BackingField: 2
     <ID>k__BackingField: 58
     <price>k__BackingField: 1000
@@ -478,7 +478,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 9158517177999279118, guid: 22bc28f2b4fe440929112704b8237ff1, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: 20fae8387345844a7bededcd296e209f, type: 3}
   - <Name>k__BackingField: AburaRamen
-    <KoreanName>k__BackingField: 35
+    <food>k__BackingField: 35
     <tag>k__BackingField: 2
     <ID>k__BackingField: 59
     <price>k__BackingField: 1000
@@ -486,7 +486,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 1104107637635105722, guid: b970f7c5df49f4dbd9b8449d2b44b291, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: e1409954405114de9b01823b6ef16543, type: 3}
   - <Name>k__BackingField: TonkotsuRamen
-    <KoreanName>k__BackingField: 36
+    <food>k__BackingField: 36
     <tag>k__BackingField: 2
     <ID>k__BackingField: 60
     <price>k__BackingField: 1000
@@ -494,7 +494,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 1420641156885054508, guid: 6854c51f22f4842708801f1710a737cc, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: 3e29d1747b0344def982e68bc7041878, type: 3}
   - <Name>k__BackingField: Tsukemen
-    <KoreanName>k__BackingField: 37
+    <food>k__BackingField: 37
     <tag>k__BackingField: 2
     <ID>k__BackingField: 61
     <price>k__BackingField: 1000
@@ -502,7 +502,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 872270813898845561, guid: b6e4916fe37e245cda7121c10929b800, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: 3e29d1747b0344def982e68bc7041878, type: 3}
   - <Name>k__BackingField: ShrimpTempura
-    <KoreanName>k__BackingField: 38
+    <food>k__BackingField: 38
     <tag>k__BackingField: 2
     <ID>k__BackingField: 62
     <price>k__BackingField: 1000
@@ -510,7 +510,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 3017459830948678046, guid: 6337281bf49984da89e33e7d0bd52f7c, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: 1fc5f67f37af24cf1930da1322b9cafd, type: 3}
   - <Name>k__BackingField: Tonkatsu
-    <KoreanName>k__BackingField: 39
+    <food>k__BackingField: 39
     <tag>k__BackingField: 2
     <ID>k__BackingField: 63
     <price>k__BackingField: 1000
@@ -518,7 +518,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 172488309569222193, guid: 4ff23f9fbae5647e6ae66d24545b3f52, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: 3cafd3be1ef4749ee82b1f9d792f0657, type: 3}
   - <Name>k__BackingField: Hambagu
-    <KoreanName>k__BackingField: 42
+    <food>k__BackingField: 42
     <tag>k__BackingField: 2
     <ID>k__BackingField: 64
     <price>k__BackingField: 1000
@@ -526,7 +526,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 2178350901961344293, guid: 1501bd6e82e294902a7c1755d1e86aad, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: 5e4fec4ef8a4f427ea1d6e65f8cf86f6, type: 3}
   - <Name>k__BackingField: Chashu
-    <KoreanName>k__BackingField: 45
+    <food>k__BackingField: 45
     <tag>k__BackingField: 2
     <ID>k__BackingField: 65
     <price>k__BackingField: 1000
@@ -534,7 +534,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 7102521602351250888, guid: 3649158f6949d40609671702b778485a, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: 9e1389df3f003471a9243df19b39f783, type: 3}
   - <Name>k__BackingField: SalmonSteak
-    <KoreanName>k__BackingField: 43
+    <food>k__BackingField: 43
     <tag>k__BackingField: 1
     <ID>k__BackingField: 66
     <price>k__BackingField: 1000
@@ -542,7 +542,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 8323801601026510530, guid: e1534ee326cae4241b1b474c7c51eece, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: 26e3a318f51bf4417a89f759c58482b9, type: 3}
   - <Name>k__BackingField: WagyuSteak
-    <KoreanName>k__BackingField: 44
+    <food>k__BackingField: 44
     <tag>k__BackingField: 2
     <ID>k__BackingField: 67
     <price>k__BackingField: 1000
@@ -550,7 +550,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 879789162398072225, guid: 4a3a76ff468d44b37944b1c0a2d127b5, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: df97c4260b92a4362afe66d8cb73b1de, type: 3}
   - <Name>k__BackingField: Onigiri
-    <KoreanName>k__BackingField: 46
+    <food>k__BackingField: 46
     <tag>k__BackingField: 2
     <ID>k__BackingField: 68
     <price>k__BackingField: 1000
@@ -558,7 +558,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 7456672238198072862, guid: 4bcd99c1e706a4a2e81bd1ad51e29232, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: ddbfb772a1cdb4106aa7ada276d7acee, type: 3}
   - <Name>k__BackingField: EbiTendon
-    <KoreanName>k__BackingField: 47
+    <food>k__BackingField: 47
     <tag>k__BackingField: 2
     <ID>k__BackingField: 69
     <price>k__BackingField: 1000
@@ -566,7 +566,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 4544470703169832204, guid: 565efd4474394422c90425c0fbcb1ccd, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: f19f04a644b954a429b548e18506771c, type: 3}
   - <Name>k__BackingField: SabaDon
-    <KoreanName>k__BackingField: 48
+    <food>k__BackingField: 48
     <tag>k__BackingField: 2
     <ID>k__BackingField: 70
     <price>k__BackingField: 1000
@@ -574,7 +574,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 5238755672133759669, guid: 091b1ba286ad14c1f9cd95677ee671d5, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: 618143385e71e4ca8ac51da15a5ed1de, type: 3}
   - <Name>k__BackingField: Gyudon
-    <KoreanName>k__BackingField: 49
+    <food>k__BackingField: 49
     <tag>k__BackingField: 2
     <ID>k__BackingField: 71
     <price>k__BackingField: 1000
@@ -582,7 +582,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 719273078047477409, guid: 6d6bc45fadd8c439592eb44a4708f2de, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: ed36d8791c6704aa0ada807759c7abb0, type: 3}
   - <Name>k__BackingField: Sakedon
-    <KoreanName>k__BackingField: 50
+    <food>k__BackingField: 50
     <tag>k__BackingField: 2
     <ID>k__BackingField: 72
     <price>k__BackingField: 1000
@@ -590,7 +590,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 7301623037957447432, guid: 45740cd4b46a341c88f560035e2d5647, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: fdc3de05dbf574997920874d3c366493, type: 3}
   - <Name>k__BackingField: Chashudon
-    <KoreanName>k__BackingField: 51
+    <food>k__BackingField: 51
     <tag>k__BackingField: 2
     <ID>k__BackingField: 73
     <price>k__BackingField: 1000
@@ -598,7 +598,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 3654126326403113629, guid: 1d915630fc4644b8db16c7feb8e3d2d9, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: 5c6362ca5b613423a9f5d6c54a58b4ca, type: 3}
   - <Name>k__BackingField: SalmonSteakdon
-    <KoreanName>k__BackingField: 52
+    <food>k__BackingField: 52
     <tag>k__BackingField: 2
     <ID>k__BackingField: 74
     <price>k__BackingField: 1000
@@ -606,7 +606,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 577707678281493577, guid: 50f67e73aec6a4e1f86df179ca8a7435, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: 8fe216f1500eb4636acd9ee4909f3837, type: 3}
   - <Name>k__BackingField: Unagidon
-    <KoreanName>k__BackingField: 53
+    <food>k__BackingField: 53
     <tag>k__BackingField: 2
     <ID>k__BackingField: 75
     <price>k__BackingField: 1000
@@ -614,7 +614,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 4201431055077167541, guid: 59607a41e19e64e8f99077b4087ad8a1, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: 0e348608327d14d609f34a994a4f8817, type: 3}
   - <Name>k__BackingField: MisoSoup
-    <KoreanName>k__BackingField: 56
+    <food>k__BackingField: 56
     <tag>k__BackingField: 2
     <ID>k__BackingField: 76
     <price>k__BackingField: 1000
@@ -622,7 +622,7 @@ MonoBehaviour:
     <Prefab>k__BackingField: {fileID: 4117434976560213589, guid: 0398a3fe9d59b4d9ebb10be843eadf30, type: 3}
     <icon>k__BackingField: {fileID: 2800000, guid: 078b1747f4f0a4578b49cb53db59b038, type: 3}
   - <Name>k__BackingField: Tea
-    <KoreanName>k__BackingField: 57
+    <food>k__BackingField: 57
     <tag>k__BackingField: 2
     <ID>k__BackingField: 77
     <price>k__BackingField: 1000

--- a/Assets/ScriptableObjects/FoodObjectSO/FoodDatabase.asset
+++ b/Assets/ScriptableObjects/FoodObjectSO/FoodDatabase.asset
@@ -14,464 +14,618 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   foodData:
   - <Name>k__BackingField: Water
-    <tag>k__BackingField: Ingredient
+    <KoreanName>k__BackingField: 13
+    <tag>k__BackingField: 0
     <ID>k__BackingField: 1
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
     <Prefab>k__BackingField: {fileID: 7658888424487957560, guid: 858d6f087e4884a44828a9972ebd862c, type: 3}
+    <icon>k__BackingField: {fileID: 2800000, guid: 57c41c1f12c2445b2ba2dd9188b3d3d9, type: 3}
   - <Name>k__BackingField: Vinegar
-    <tag>k__BackingField: Ingredient
+    <KoreanName>k__BackingField: 12
+    <tag>k__BackingField: 0
     <ID>k__BackingField: 2
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
     <Prefab>k__BackingField: {fileID: 7497115926558726248, guid: fdd184d5328a04b2d92528018c2a4579, type: 3}
+    <icon>k__BackingField: {fileID: 2800000, guid: ea81d37d2c27b47458683d2bf90822d8, type: 3}
   - <Name>k__BackingField: Soysauce
-    <tag>k__BackingField: Ingredient
+    <KoreanName>k__BackingField: 15
+    <tag>k__BackingField: 0
     <ID>k__BackingField: 3
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
     <Prefab>k__BackingField: {fileID: 3202690755826013567, guid: 6795187f7503a4d59bec7eab34307513, type: 3}
+    <icon>k__BackingField: {fileID: 2800000, guid: 38277244fda184b3f9bf001bee1a912b, type: 3}
   - <Name>k__BackingField: Miso
-    <tag>k__BackingField: Ingredient
+    <KoreanName>k__BackingField: 16
+    <tag>k__BackingField: 0
     <ID>k__BackingField: 4
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
     <Prefab>k__BackingField: {fileID: 3505866646548267482, guid: ae6fe198d936542298b80a2e4d2ecee8, type: 3}
+    <icon>k__BackingField: {fileID: 2800000, guid: be352e9356ef64e15bc73c86d3ac587a, type: 3}
   - <Name>k__BackingField: Rice
-    <tag>k__BackingField: Ingredient
+    <KoreanName>k__BackingField: 0
+    <tag>k__BackingField: 0
     <ID>k__BackingField: 5
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
     <Prefab>k__BackingField: {fileID: 9083243063744714783, guid: dc7a29cfd1e3d423186054b30dede15b, type: 3}
+    <icon>k__BackingField: {fileID: 2800000, guid: 4ed82be0d8c3d45f1a9979a7ddca8537, type: 3}
   - <Name>k__BackingField: FryPowder
-    <tag>k__BackingField: Ingredient
+    <KoreanName>k__BackingField: 17
+    <tag>k__BackingField: 0
     <ID>k__BackingField: 6
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
     <Prefab>k__BackingField: {fileID: 7658888424487957560, guid: 858d6f087e4884a44828a9972ebd862c, type: 3}
+    <icon>k__BackingField: {fileID: 2800000, guid: 6c93784436b1545bcb48efed094102c3, type: 3}
   - <Name>k__BackingField: Noodle
-    <tag>k__BackingField: Ingredient
+    <KoreanName>k__BackingField: 14
+    <tag>k__BackingField: 0
     <ID>k__BackingField: 7
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
     <Prefab>k__BackingField: {fileID: 3067885276403880707, guid: 2e5c95145ab3842ac904f2aba75af068, type: 3}
+    <icon>k__BackingField: {fileID: 2800000, guid: 44fbece8093fc4361bd7815195eeddd5, type: 3}
   - <Name>k__BackingField: Tofu
-    <tag>k__BackingField: Ingredient
+    <KoreanName>k__BackingField: 2
+    <tag>k__BackingField: 0
     <ID>k__BackingField: 8
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
-    <Prefab>k__BackingField: {fileID: 0}
+    <Prefab>k__BackingField: {fileID: 2569467188940230205, guid: 62fe09e6fdfc348a5ae1c6a52f799241, type: 3}
+    <icon>k__BackingField: {fileID: 2800000, guid: 3042022ba4748422fbc4760a27398995, type: 3}
   - <Name>k__BackingField: Egg
-    <tag>k__BackingField: Ingredient
+    <KoreanName>k__BackingField: 1
+    <tag>k__BackingField: 0
     <ID>k__BackingField: 9
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
     <Prefab>k__BackingField: {fileID: 8389371753922280744, guid: d2325c2c59a9444009c2bc43ac13061c, type: 3}
+    <icon>k__BackingField: {fileID: 2800000, guid: d51a4ac8e10bb49eb87772998006c838, type: 3}
   - <Name>k__BackingField: Pork
-    <tag>k__BackingField: Ingredient
+    <KoreanName>k__BackingField: 11
+    <tag>k__BackingField: 0
     <ID>k__BackingField: 10
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
     <Prefab>k__BackingField: {fileID: 6881908385715226372, guid: 0b846b3416f4d412090b11f4bc22ab0f, type: 3}
+    <icon>k__BackingField: {fileID: 2800000, guid: ea8db274cc03b41928a6284e9ef5ae8e, type: 3}
   - <Name>k__BackingField: Beef
-    <tag>k__BackingField: Ingredient
+    <KoreanName>k__BackingField: 6
+    <tag>k__BackingField: 0
     <ID>k__BackingField: 11
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
     <Prefab>k__BackingField: {fileID: 6274084391122988245, guid: 9eee2e4b908a24ffa889fc49be8cc8a6, type: 3}
+    <icon>k__BackingField: {fileID: 2800000, guid: 07456d10633e04d71853135c3bf52878, type: 3}
   - <Name>k__BackingField: Shrimp
-    <tag>k__BackingField: Ingredient
+    <KoreanName>k__BackingField: 4
+    <tag>k__BackingField: 0
     <ID>k__BackingField: 12
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
     <Prefab>k__BackingField: {fileID: 2604253987008481563, guid: 872801591ea4445e59b45584beca57c6, type: 3}
+    <icon>k__BackingField: {fileID: 2800000, guid: 8f59dc0b9a3ee4c87bf5d4d3fcf59eb8, type: 3}
   - <Name>k__BackingField: Vegetable
-    <tag>k__BackingField: Ingredient
+    <KoreanName>k__BackingField: 19
+    <tag>k__BackingField: 0
     <ID>k__BackingField: 13
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
     <Prefab>k__BackingField: {fileID: 1843141169661942814, guid: d278d01a1c3f6416f95c5c53eb3f1fdb, type: 3}
+    <icon>k__BackingField: {fileID: 2800000, guid: eb8bd001eadaa40eeb8010278dac92e0, type: 3}
   - <Name>k__BackingField: Flatfish
-    <tag>k__BackingField: Ingredient
+    <KoreanName>k__BackingField: 3
+    <tag>k__BackingField: 0
     <ID>k__BackingField: 14
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
     <Prefab>k__BackingField: {fileID: 5773488423304670987, guid: a8fb2a1e56c1f41699379752eb62a4ce, type: 3}
+    <icon>k__BackingField: {fileID: 2800000, guid: a7ebe0897cc8b4fe9be4d6d94df071c2, type: 3}
   - <Name>k__BackingField: Saba
-    <tag>k__BackingField: Ingredient
+    <KoreanName>k__BackingField: 5
+    <tag>k__BackingField: 0
     <ID>k__BackingField: 15
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
     <Prefab>k__BackingField: {fileID: 5773488423304670987, guid: a8fb2a1e56c1f41699379752eb62a4ce, type: 3}
+    <icon>k__BackingField: {fileID: 2800000, guid: a7ebe0897cc8b4fe9be4d6d94df071c2, type: 3}
   - <Name>k__BackingField: Tuna
-    <tag>k__BackingField: Ingredient
+    <KoreanName>k__BackingField: 7
+    <tag>k__BackingField: 0
     <ID>k__BackingField: 16
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
     <Prefab>k__BackingField: {fileID: 5773488423304670987, guid: a8fb2a1e56c1f41699379752eb62a4ce, type: 3}
+    <icon>k__BackingField: {fileID: 2800000, guid: a7ebe0897cc8b4fe9be4d6d94df071c2, type: 3}
   - <Name>k__BackingField: Salmon
-    <tag>k__BackingField: Ingredient
+    <KoreanName>k__BackingField: 9
+    <tag>k__BackingField: 0
     <ID>k__BackingField: 17
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
     <Prefab>k__BackingField: {fileID: 5773488423304670987, guid: a8fb2a1e56c1f41699379752eb62a4ce, type: 3}
+    <icon>k__BackingField: {fileID: 2800000, guid: a7ebe0897cc8b4fe9be4d6d94df071c2, type: 3}
   - <Name>k__BackingField: Unagi
-    <tag>k__BackingField: Ingredient
+    <KoreanName>k__BackingField: 10
+    <tag>k__BackingField: 0
     <ID>k__BackingField: 18
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
     <Prefab>k__BackingField: {fileID: 5773488423304670987, guid: a8fb2a1e56c1f41699379752eb62a4ce, type: 3}
+    <icon>k__BackingField: {fileID: 2800000, guid: a7ebe0897cc8b4fe9be4d6d94df071c2, type: 3}
   - <Name>k__BackingField: CookedRicePot
-    <tag>k__BackingField: Predish
+    <KoreanName>k__BackingField: 60
+    <tag>k__BackingField: 1
     <ID>k__BackingField: 19
     <price>k__BackingField: 1000
-    <level>k__BackingField: 0
+    <level>k__BackingField: 1
     <Prefab>k__BackingField: {fileID: 7696103292884469837, guid: 6f5ea644a7dfd4694899f70d65628207, type: 3}
+    <icon>k__BackingField: {fileID: 0}
   - <Name>k__BackingField: CookedRice
-    <tag>k__BackingField: Predish
+    <KoreanName>k__BackingField: 58
+    <tag>k__BackingField: 1
     <ID>k__BackingField: 20
     <price>k__BackingField: 1000
-    <level>k__BackingField: 0
+    <level>k__BackingField: 1
     <Prefab>k__BackingField: {fileID: 4323809633325535547, guid: d4c4c6549a0c14d58ba1fb9dce93a8d6, type: 3}
+    <icon>k__BackingField: {fileID: 0}
   - <Name>k__BackingField: EggRoll
-    <tag>k__BackingField: Predish
+    <KoreanName>k__BackingField: 61
+    <tag>k__BackingField: 1
     <ID>k__BackingField: 21
     <price>k__BackingField: 1000
-    <level>k__BackingField: 0
+    <level>k__BackingField: 1
     <Prefab>k__BackingField: {fileID: 9032505915419756735, guid: 37906f56bca534bc49351cf1bb17ed10, type: 3}
+    <icon>k__BackingField: {fileID: 0}
   - <Name>k__BackingField: FriedTofu
-    <tag>k__BackingField: Predish
+    <KoreanName>k__BackingField: 63
+    <tag>k__BackingField: 1
     <ID>k__BackingField: 22
     <price>k__BackingField: 1000
-    <level>k__BackingField: 0
+    <level>k__BackingField: 1
     <Prefab>k__BackingField: {fileID: 7153209375705375888, guid: db231e412588d46e2a526846be501bf8, type: 3}
+    <icon>k__BackingField: {fileID: 0}
   - <Name>k__BackingField: GrilledBeefNVeg
-    <tag>k__BackingField: Predish
+    <KoreanName>k__BackingField: 68
+    <tag>k__BackingField: 1
     <ID>k__BackingField: 23
     <price>k__BackingField: 1000
-    <level>k__BackingField: 0
+    <level>k__BackingField: 1
     <Prefab>k__BackingField: {fileID: 3349099462871534991, guid: b6ddc8ffa634b4c0b99bf9a89b160a58, type: 3}
+    <icon>k__BackingField: {fileID: 0}
   - <Name>k__BackingField: GrilledMackerel
-    <tag>k__BackingField: Predish
+    <KoreanName>k__BackingField: 83
+    <tag>k__BackingField: 1
     <ID>k__BackingField: 24
     <price>k__BackingField: 1000
-    <level>k__BackingField: 0
+    <level>k__BackingField: 1
     <Prefab>k__BackingField: {fileID: 1895120071186820260, guid: d4706ce4f959b4dc4a20b75584d0767e, type: 3}
+    <icon>k__BackingField: {fileID: 0}
   - <Name>k__BackingField: GrilledBeef
-    <tag>k__BackingField: Predish
+    <KoreanName>k__BackingField: 70
+    <tag>k__BackingField: 1
     <ID>k__BackingField: 25
     <price>k__BackingField: 1000
-    <level>k__BackingField: 0
+    <level>k__BackingField: 1
     <Prefab>k__BackingField: {fileID: 5994628728736546187, guid: 8e037ae0c80b8424893f20f3b1a88135, type: 3}
+    <icon>k__BackingField: {fileID: 0}
   - <Name>k__BackingField: GrilledEel
-    <tag>k__BackingField: Predish
+    <KoreanName>k__BackingField: 0
+    <tag>k__BackingField: 1
     <ID>k__BackingField: 26
     <price>k__BackingField: 1000
-    <level>k__BackingField: 0
+    <level>k__BackingField: 1
     <Prefab>k__BackingField: {fileID: 4147544906032101272, guid: a8107ac99399f40a5b7d68b2693063ad, type: 3}
+    <icon>k__BackingField: {fileID: 0}
   - <Name>k__BackingField: GrilledPork
-    <tag>k__BackingField: Predish
+    <KoreanName>k__BackingField: 79
+    <tag>k__BackingField: 1
     <ID>k__BackingField: 27
     <price>k__BackingField: 1000
-    <level>k__BackingField: 0
+    <level>k__BackingField: 1
     <Prefab>k__BackingField: {fileID: 7772951563969828875, guid: f84e72e3410f84a3eb9813d497400192, type: 3}
+    <icon>k__BackingField: {fileID: 0}
   - <Name>k__BackingField: GrilledSalmon
-    <tag>k__BackingField: Predish
+    <KoreanName>k__BackingField: 74
+    <tag>k__BackingField: 1
     <ID>k__BackingField: 28
     <price>k__BackingField: 1000
-    <level>k__BackingField: 0
+    <level>k__BackingField: 1
     <Prefab>k__BackingField: {fileID: 2670225449858919766, guid: 02f2a6ae354274ccbbdc3cffbea8702b, type: 3}
+    <icon>k__BackingField: {fileID: 0}
   - <Name>k__BackingField: GrilledShrimp
-    <tag>k__BackingField: Predish
+    <KoreanName>k__BackingField: 66
+    <tag>k__BackingField: 1
     <ID>k__BackingField: 29
     <price>k__BackingField: 1000
-    <level>k__BackingField: 0
+    <level>k__BackingField: 1
     <Prefab>k__BackingField: {fileID: 4280993578947105436, guid: 9f147ac004d2f4c768096ab838075354, type: 3}
+    <icon>k__BackingField: {fileID: 0}
   - <Name>k__BackingField: PiecedSalmon
-    <tag>k__BackingField: Predish
+    <KoreanName>k__BackingField: 73
+    <tag>k__BackingField: 1
     <ID>k__BackingField: 30
     <price>k__BackingField: 1000
-    <level>k__BackingField: 0
+    <level>k__BackingField: 1
     <Prefab>k__BackingField: {fileID: 9217147774225242882, guid: 0412937935b17459396673469db2e6f8, type: 3}
+    <icon>k__BackingField: {fileID: 0}
   - <Name>k__BackingField: PorkCutlet
-    <tag>k__BackingField: Predish
+    <KoreanName>k__BackingField: 81
+    <tag>k__BackingField: 1
     <ID>k__BackingField: 31
     <price>k__BackingField: 1000
-    <level>k__BackingField: 0
+    <level>k__BackingField: 1
     <Prefab>k__BackingField: {fileID: 5820098932443901850, guid: bca609429f70b4caab2f5b6497b833e1, type: 3}
+    <icon>k__BackingField: {fileID: 0}
   - <Name>k__BackingField: RamenSoupBowl
-    <tag>k__BackingField: Predish
+    <KoreanName>k__BackingField: 59
+    <tag>k__BackingField: 1
     <ID>k__BackingField: 32
     <price>k__BackingField: 1000
-    <level>k__BackingField: 0
+    <level>k__BackingField: 1
     <Prefab>k__BackingField: {fileID: 4586437712627807600, guid: d3580d2d6c5e64a32aca28024d7250de, type: 3}
+    <icon>k__BackingField: {fileID: 0}
   - <Name>k__BackingField: RamenSoup
-    <tag>k__BackingField: Predish
+    <KoreanName>k__BackingField: 59
+    <tag>k__BackingField: 1
     <ID>k__BackingField: 33
     <price>k__BackingField: 1000
-    <level>k__BackingField: 0
+    <level>k__BackingField: 1
     <Prefab>k__BackingField: {fileID: 2760817210610945848, guid: eefccbc40764c4c83b6a535218eae056, type: 3}
+    <icon>k__BackingField: {fileID: 0}
   - <Name>k__BackingField: RawBeef
-    <tag>k__BackingField: Predish
+    <KoreanName>k__BackingField: 0
+    <tag>k__BackingField: 1
     <ID>k__BackingField: 34
     <price>k__BackingField: 1000
-    <level>k__BackingField: 0
+    <level>k__BackingField: 1
     <Prefab>k__BackingField: {fileID: 6586992115549774392, guid: b7584b71b1450496988917ccc9e6899e, type: 3}
+    <icon>k__BackingField: {fileID: 0}
   - <Name>k__BackingField: TrimmedBeef
-    <tag>k__BackingField: Predish
+    <KoreanName>k__BackingField: 68
+    <tag>k__BackingField: 1
     <ID>k__BackingField: 35
     <price>k__BackingField: 1000
-    <level>k__BackingField: 0
+    <level>k__BackingField: 1
     <Prefab>k__BackingField: {fileID: 4414265435317524576, guid: be99d6ffae8074d40b4e47737d197e9a, type: 3}
+    <icon>k__BackingField: {fileID: 0}
   - <Name>k__BackingField: TrimmedEel
-    <tag>k__BackingField: Predish
+    <KoreanName>k__BackingField: 64
+    <tag>k__BackingField: 1
     <ID>k__BackingField: 36
     <price>k__BackingField: 1000
-    <level>k__BackingField: 0
+    <level>k__BackingField: 1
     <Prefab>k__BackingField: {fileID: 3498816469846616115, guid: 58df8d258db56494eb1c321a386c5dea, type: 3}
+    <icon>k__BackingField: {fileID: 0}
   - <Name>k__BackingField: TrimmedFlatfish
-    <tag>k__BackingField: Predish
+    <KoreanName>k__BackingField: 64
+    <tag>k__BackingField: 1
     <ID>k__BackingField: 37
     <price>k__BackingField: 1000
-    <level>k__BackingField: 0
+    <level>k__BackingField: 1
     <Prefab>k__BackingField: {fileID: 5493475046638010204, guid: 05eb6715566914e25ae805129b6d60f0, type: 3}
+    <icon>k__BackingField: {fileID: 0}
   - <Name>k__BackingField: TrimmedPork
-    <tag>k__BackingField: Predish
+    <KoreanName>k__BackingField: 78
+    <tag>k__BackingField: 1
     <ID>k__BackingField: 38
     <price>k__BackingField: 1000
-    <level>k__BackingField: 0
+    <level>k__BackingField: 1
     <Prefab>k__BackingField: {fileID: 6172634807142451179, guid: 1f74ca87327464b639345dd3304fca7d, type: 3}
+    <icon>k__BackingField: {fileID: 0}
   - <Name>k__BackingField: TrimmedSaba
-    <tag>k__BackingField: Predish
+    <KoreanName>k__BackingField: 67
+    <tag>k__BackingField: 1
     <ID>k__BackingField: 39
     <price>k__BackingField: 1000
-    <level>k__BackingField: 0
+    <level>k__BackingField: 1
     <Prefab>k__BackingField: {fileID: 5383931453605002147, guid: e8a4ed008a7e5451c8aa3e4e660a2d85, type: 3}
+    <icon>k__BackingField: {fileID: 0}
   - <Name>k__BackingField: TrimmedSalmon
-    <tag>k__BackingField: Predish
+    <KoreanName>k__BackingField: 72
+    <tag>k__BackingField: 1
     <ID>k__BackingField: 40
     <price>k__BackingField: 1000
-    <level>k__BackingField: 0
+    <level>k__BackingField: 1
     <Prefab>k__BackingField: {fileID: 9193149628080068938, guid: 03d175065f7b244b9b14bbf2c21e1e98, type: 3}
+    <icon>k__BackingField: {fileID: 0}
   - <Name>k__BackingField: TrimmedShrimp
-    <tag>k__BackingField: Predish
+    <KoreanName>k__BackingField: 65
+    <tag>k__BackingField: 1
     <ID>k__BackingField: 41
     <price>k__BackingField: 1000
-    <level>k__BackingField: 0
+    <level>k__BackingField: 1
     <Prefab>k__BackingField: {fileID: 778079195131482413, guid: 33ea1cfb6761144d4b896578baad2dd5, type: 3}
+    <icon>k__BackingField: {fileID: 0}
   - <Name>k__BackingField: TrimmedTofu
-    <tag>k__BackingField: Predish
+    <KoreanName>k__BackingField: 84
+    <tag>k__BackingField: 1
     <ID>k__BackingField: 42
     <price>k__BackingField: 1000
-    <level>k__BackingField: 0
+    <level>k__BackingField: 1
     <Prefab>k__BackingField: {fileID: 8844105939027407574, guid: 6bc72b6cccef14513bfe1c0f6e5db135, type: 3}
+    <icon>k__BackingField: {fileID: 0}
   - <Name>k__BackingField: TrimmedTunaAkami
-    <tag>k__BackingField: Predish
+    <KoreanName>k__BackingField: 71
+    <tag>k__BackingField: 1
     <ID>k__BackingField: 43
     <price>k__BackingField: 1000
-    <level>k__BackingField: 0
+    <level>k__BackingField: 1
     <Prefab>k__BackingField: {fileID: 1479845603273236116, guid: b079cd47e1f5640dca0f50616ed49893, type: 3}
+    <icon>k__BackingField: {fileID: 0}
   - <Name>k__BackingField: TrimmedTunaDoro
-    <tag>k__BackingField: Predish
+    <KoreanName>k__BackingField: 77
+    <tag>k__BackingField: 1
     <ID>k__BackingField: 44
     <price>k__BackingField: 1000
-    <level>k__BackingField: 0
+    <level>k__BackingField: 1
     <Prefab>k__BackingField: {fileID: 4314160130475415669, guid: 69e507e9c2083464cb77d25446c43c06, type: 3}
+    <icon>k__BackingField: {fileID: 0}
   - <Name>k__BackingField: TrimmedVeg
-    <tag>k__BackingField: Predish
+    <KoreanName>k__BackingField: 82
+    <tag>k__BackingField: 1
     <ID>k__BackingField: 45
     <price>k__BackingField: 1000
-    <level>k__BackingField: 0
+    <level>k__BackingField: 1
     <Prefab>k__BackingField: {fileID: 5003013232451133471, guid: ee5f1750a593043ae973f15a8222dad3, type: 3}
+    <icon>k__BackingField: {fileID: 0}
   - <Name>k__BackingField: EggSushi
-    <tag>k__BackingField: Dish
+    <KoreanName>k__BackingField: 21
+    <tag>k__BackingField: 2
     <ID>k__BackingField: 46
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
     <Prefab>k__BackingField: {fileID: 524390802597008268, guid: 338b3998119ca489fa89d1b2329bb19b, type: 3}
+    <icon>k__BackingField: {fileID: 2800000, guid: 85e4d9ad6154e4458b2ca750604dcaac, type: 3}
   - <Name>k__BackingField: FriedTofuSushi
-    <tag>k__BackingField: Dish
+    <KoreanName>k__BackingField: 22
+    <tag>k__BackingField: 2
     <ID>k__BackingField: 47
     <price>k__BackingField: 1000
     <level>k__BackingField: 2
     <Prefab>k__BackingField: {fileID: 1819758596141938398, guid: b839b4948b302440ab4b438124c5ea2b, type: 3}
+    <icon>k__BackingField: {fileID: 2800000, guid: cb3045282841e45e1aa5fdff05ad0003, type: 3}
   - <Name>k__BackingField: MackerelSushi
-    <tag>k__BackingField: Dish
+    <KoreanName>k__BackingField: 25
+    <tag>k__BackingField: 2
     <ID>k__BackingField: 48
     <price>k__BackingField: 1000
     <level>k__BackingField: 2
     <Prefab>k__BackingField: {fileID: 8831638701008892303, guid: 6fb69d8b26f704aa8bb1846a6365a7c7, type: 3}
+    <icon>k__BackingField: {fileID: 2800000, guid: d921233d5588e4559b674e7a03558fa4, type: 3}
   - <Name>k__BackingField: FlatfishSushi
-    <tag>k__BackingField: Dish
+    <KoreanName>k__BackingField: 23
+    <tag>k__BackingField: 2
     <ID>k__BackingField: 49
     <price>k__BackingField: 1000
     <level>k__BackingField: 3
     <Prefab>k__BackingField: {fileID: 2223276481628621662, guid: 72449f23490674ae2a30e075ca38b594, type: 3}
+    <icon>k__BackingField: {fileID: 2800000, guid: ea603508e932c46f1b021aae94aa0d14, type: 3}
   - <Name>k__BackingField: ShrimpSushi
-    <tag>k__BackingField: Dish
+    <KoreanName>k__BackingField: 24
+    <tag>k__BackingField: 2
     <ID>k__BackingField: 50
     <price>k__BackingField: 1000
     <level>k__BackingField: 3
     <Prefab>k__BackingField: {fileID: 2993517041642147389, guid: 71d8b82d15c0649129e3746152160a33, type: 3}
+    <icon>k__BackingField: {fileID: 2800000, guid: 1a0e0b9d44ee04bb78058f11c6d1fe2e, type: 3}
   - <Name>k__BackingField: BeefSushi
-    <tag>k__BackingField: Dish
+    <KoreanName>k__BackingField: 26
+    <tag>k__BackingField: 2
     <ID>k__BackingField: 51
     <price>k__BackingField: 1000
     <level>k__BackingField: 4
     <Prefab>k__BackingField: {fileID: 2169001374624953386, guid: af48213ec5bab4cadbbd684c51a90d1c, type: 3}
+    <icon>k__BackingField: {fileID: 2800000, guid: 38f9794ecc6cc4e5c98ee283f3b46671, type: 3}
   - <Name>k__BackingField: SalmonSushi
-    <tag>k__BackingField: Dish
+    <KoreanName>k__BackingField: 28
+    <tag>k__BackingField: 2
     <ID>k__BackingField: 52
     <price>k__BackingField: 1000
     <level>k__BackingField: 4
     <Prefab>k__BackingField: {fileID: 5615254719090856724, guid: d0f0e4aa522ed4f35b75e0c6d3f9915b, type: 3}
+    <icon>k__BackingField: {fileID: 2800000, guid: 8c4afa6d834b34f2bb1259ca3ea83321, type: 3}
   - <Name>k__BackingField: TunaAkamiSushi
-    <tag>k__BackingField: Dish
+    <KoreanName>k__BackingField: 27
+    <tag>k__BackingField: 2
     <ID>k__BackingField: 53
     <price>k__BackingField: 1000
     <level>k__BackingField: 5
     <Prefab>k__BackingField: {fileID: 8142243786085134417, guid: 72de3eaf62a974135aa1cf8e912de165, type: 3}
+    <icon>k__BackingField: {fileID: 2800000, guid: 6beede8415f894047bf48bf7547c480a, type: 3}
   - <Name>k__BackingField: SmokedSalmonSushi
-    <tag>k__BackingField: Dish
+    <KoreanName>k__BackingField: 29
+    <tag>k__BackingField: 2
     <ID>k__BackingField: 54
     <price>k__BackingField: 1000
     <level>k__BackingField: 6
     <Prefab>k__BackingField: {fileID: 2646821394788172715, guid: a1aa0226930c140629344addea6db018, type: 3}
+    <icon>k__BackingField: {fileID: 2800000, guid: 6420e0a9b653843419101e1bc3bf4ae2, type: 3}
   - <Name>k__BackingField: UnagiSushi
-    <tag>k__BackingField: Dish
+    <KoreanName>k__BackingField: 30
+    <tag>k__BackingField: 2
     <ID>k__BackingField: 55
     <price>k__BackingField: 1000
     <level>k__BackingField: 7
     <Prefab>k__BackingField: {fileID: 3002752885237273843, guid: 0cf458fababce4902affa1108040bf87, type: 3}
+    <icon>k__BackingField: {fileID: 2800000, guid: 3468b5fa3f8a242f182057774f8b6976, type: 3}
   - <Name>k__BackingField: TunaDoroSushi
-    <tag>k__BackingField: Dish
+    <KoreanName>k__BackingField: 31
+    <tag>k__BackingField: 2
     <ID>k__BackingField: 56
     <price>k__BackingField: 1000
     <level>k__BackingField: 8
     <Prefab>k__BackingField: {fileID: 8753923425398735485, guid: 788b064da0fb74f1ab0ec714964a7807, type: 3}
+    <icon>k__BackingField: {fileID: 2800000, guid: e9ba11409babe44a0923d023ac420661, type: 3}
   - <Name>k__BackingField: ShoyuRamen
-    <tag>k__BackingField: Dish
+    <KoreanName>k__BackingField: 33
+    <tag>k__BackingField: 2
     <ID>k__BackingField: 57
     <price>k__BackingField: 1000
     <level>k__BackingField: 3
     <Prefab>k__BackingField: {fileID: 902126896480971816, guid: d0c5893ec54f14775bd5a01615d9d532, type: 3}
+    <icon>k__BackingField: {fileID: 2800000, guid: 52015edecceea4ef1864e6fa5eb8f42c, type: 3}
   - <Name>k__BackingField: MisoRamen
-    <tag>k__BackingField: Dish
+    <KoreanName>k__BackingField: 34
+    <tag>k__BackingField: 2
     <ID>k__BackingField: 58
     <price>k__BackingField: 1000
     <level>k__BackingField: 4
     <Prefab>k__BackingField: {fileID: 9158517177999279118, guid: 22bc28f2b4fe440929112704b8237ff1, type: 3}
+    <icon>k__BackingField: {fileID: 2800000, guid: 20fae8387345844a7bededcd296e209f, type: 3}
   - <Name>k__BackingField: AburaRamen
-    <tag>k__BackingField: Dish
+    <KoreanName>k__BackingField: 35
+    <tag>k__BackingField: 2
     <ID>k__BackingField: 59
     <price>k__BackingField: 1000
     <level>k__BackingField: 5
     <Prefab>k__BackingField: {fileID: 1104107637635105722, guid: b970f7c5df49f4dbd9b8449d2b44b291, type: 3}
+    <icon>k__BackingField: {fileID: 2800000, guid: e1409954405114de9b01823b6ef16543, type: 3}
   - <Name>k__BackingField: TonkotsuRamen
-    <tag>k__BackingField: Dish
+    <KoreanName>k__BackingField: 36
+    <tag>k__BackingField: 2
     <ID>k__BackingField: 60
     <price>k__BackingField: 1000
     <level>k__BackingField: 6
     <Prefab>k__BackingField: {fileID: 1420641156885054508, guid: 6854c51f22f4842708801f1710a737cc, type: 3}
+    <icon>k__BackingField: {fileID: 2800000, guid: 3e29d1747b0344def982e68bc7041878, type: 3}
   - <Name>k__BackingField: Tsukemen
-    <tag>k__BackingField: Dish
+    <KoreanName>k__BackingField: 37
+    <tag>k__BackingField: 2
     <ID>k__BackingField: 61
     <price>k__BackingField: 1000
     <level>k__BackingField: 8
     <Prefab>k__BackingField: {fileID: 872270813898845561, guid: b6e4916fe37e245cda7121c10929b800, type: 3}
+    <icon>k__BackingField: {fileID: 2800000, guid: 3e29d1747b0344def982e68bc7041878, type: 3}
   - <Name>k__BackingField: ShrimpTempura
-    <tag>k__BackingField: Dish
+    <KoreanName>k__BackingField: 38
+    <tag>k__BackingField: 2
     <ID>k__BackingField: 62
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
     <Prefab>k__BackingField: {fileID: 3017459830948678046, guid: 6337281bf49984da89e33e7d0bd52f7c, type: 3}
+    <icon>k__BackingField: {fileID: 2800000, guid: 1fc5f67f37af24cf1930da1322b9cafd, type: 3}
   - <Name>k__BackingField: Tonkatsu
-    <tag>k__BackingField: Dish
+    <KoreanName>k__BackingField: 39
+    <tag>k__BackingField: 2
     <ID>k__BackingField: 63
     <price>k__BackingField: 1000
     <level>k__BackingField: 4
     <Prefab>k__BackingField: {fileID: 172488309569222193, guid: 4ff23f9fbae5647e6ae66d24545b3f52, type: 3}
+    <icon>k__BackingField: {fileID: 2800000, guid: 3cafd3be1ef4749ee82b1f9d792f0657, type: 3}
   - <Name>k__BackingField: Hambagu
-    <tag>k__BackingField: Dish
+    <KoreanName>k__BackingField: 42
+    <tag>k__BackingField: 2
     <ID>k__BackingField: 64
     <price>k__BackingField: 1000
     <level>k__BackingField: 3
     <Prefab>k__BackingField: {fileID: 2178350901961344293, guid: 1501bd6e82e294902a7c1755d1e86aad, type: 3}
+    <icon>k__BackingField: {fileID: 2800000, guid: 5e4fec4ef8a4f427ea1d6e65f8cf86f6, type: 3}
   - <Name>k__BackingField: Chashu
-    <tag>k__BackingField: Dish
+    <KoreanName>k__BackingField: 45
+    <tag>k__BackingField: 2
     <ID>k__BackingField: 65
     <price>k__BackingField: 1000
     <level>k__BackingField: 5
     <Prefab>k__BackingField: {fileID: 7102521602351250888, guid: 3649158f6949d40609671702b778485a, type: 3}
+    <icon>k__BackingField: {fileID: 2800000, guid: 9e1389df3f003471a9243df19b39f783, type: 3}
   - <Name>k__BackingField: SalmonSteak
-    <tag>k__BackingField: Dish
+    <KoreanName>k__BackingField: 43
+    <tag>k__BackingField: 1
     <ID>k__BackingField: 66
     <price>k__BackingField: 1000
     <level>k__BackingField: 6
     <Prefab>k__BackingField: {fileID: 8323801601026510530, guid: e1534ee326cae4241b1b474c7c51eece, type: 3}
+    <icon>k__BackingField: {fileID: 2800000, guid: 26e3a318f51bf4417a89f759c58482b9, type: 3}
   - <Name>k__BackingField: WagyuSteak
-    <tag>k__BackingField: Dish
+    <KoreanName>k__BackingField: 44
+    <tag>k__BackingField: 2
     <ID>k__BackingField: 67
     <price>k__BackingField: 1000
     <level>k__BackingField: 6
     <Prefab>k__BackingField: {fileID: 879789162398072225, guid: 4a3a76ff468d44b37944b1c0a2d127b5, type: 3}
+    <icon>k__BackingField: {fileID: 2800000, guid: df97c4260b92a4362afe66d8cb73b1de, type: 3}
   - <Name>k__BackingField: Onigiri
-    <tag>k__BackingField: Dish
+    <KoreanName>k__BackingField: 46
+    <tag>k__BackingField: 2
     <ID>k__BackingField: 68
     <price>k__BackingField: 1000
     <level>k__BackingField: 1
     <Prefab>k__BackingField: {fileID: 7456672238198072862, guid: 4bcd99c1e706a4a2e81bd1ad51e29232, type: 3}
+    <icon>k__BackingField: {fileID: 2800000, guid: ddbfb772a1cdb4106aa7ada276d7acee, type: 3}
   - <Name>k__BackingField: EbiTendon
-    <tag>k__BackingField: Dish
+    <KoreanName>k__BackingField: 47
+    <tag>k__BackingField: 2
     <ID>k__BackingField: 69
     <price>k__BackingField: 1000
     <level>k__BackingField: 2
     <Prefab>k__BackingField: {fileID: 4544470703169832204, guid: 565efd4474394422c90425c0fbcb1ccd, type: 3}
+    <icon>k__BackingField: {fileID: 2800000, guid: f19f04a644b954a429b548e18506771c, type: 3}
   - <Name>k__BackingField: SabaDon
-    <tag>k__BackingField: Dish
+    <KoreanName>k__BackingField: 48
+    <tag>k__BackingField: 2
     <ID>k__BackingField: 70
     <price>k__BackingField: 1000
     <level>k__BackingField: 3
     <Prefab>k__BackingField: {fileID: 5238755672133759669, guid: 091b1ba286ad14c1f9cd95677ee671d5, type: 3}
+    <icon>k__BackingField: {fileID: 2800000, guid: 618143385e71e4ca8ac51da15a5ed1de, type: 3}
   - <Name>k__BackingField: Gyudon
-    <tag>k__BackingField: Dish
+    <KoreanName>k__BackingField: 49
+    <tag>k__BackingField: 2
     <ID>k__BackingField: 71
     <price>k__BackingField: 1000
     <level>k__BackingField: 4
     <Prefab>k__BackingField: {fileID: 719273078047477409, guid: 6d6bc45fadd8c439592eb44a4708f2de, type: 3}
+    <icon>k__BackingField: {fileID: 2800000, guid: ed36d8791c6704aa0ada807759c7abb0, type: 3}
   - <Name>k__BackingField: Sakedon
-    <tag>k__BackingField: Dish
+    <KoreanName>k__BackingField: 50
+    <tag>k__BackingField: 2
     <ID>k__BackingField: 72
     <price>k__BackingField: 1000
     <level>k__BackingField: 5
     <Prefab>k__BackingField: {fileID: 7301623037957447432, guid: 45740cd4b46a341c88f560035e2d5647, type: 3}
+    <icon>k__BackingField: {fileID: 2800000, guid: fdc3de05dbf574997920874d3c366493, type: 3}
   - <Name>k__BackingField: Chashudon
-    <tag>k__BackingField: Dish
+    <KoreanName>k__BackingField: 51
+    <tag>k__BackingField: 2
     <ID>k__BackingField: 73
     <price>k__BackingField: 1000
     <level>k__BackingField: 6
     <Prefab>k__BackingField: {fileID: 3654126326403113629, guid: 1d915630fc4644b8db16c7feb8e3d2d9, type: 3}
+    <icon>k__BackingField: {fileID: 2800000, guid: 5c6362ca5b613423a9f5d6c54a58b4ca, type: 3}
   - <Name>k__BackingField: SalmonSteakdon
-    <tag>k__BackingField: Dish
+    <KoreanName>k__BackingField: 52
+    <tag>k__BackingField: 2
     <ID>k__BackingField: 74
     <price>k__BackingField: 1000
     <level>k__BackingField: 7
     <Prefab>k__BackingField: {fileID: 577707678281493577, guid: 50f67e73aec6a4e1f86df179ca8a7435, type: 3}
+    <icon>k__BackingField: {fileID: 2800000, guid: 8fe216f1500eb4636acd9ee4909f3837, type: 3}
   - <Name>k__BackingField: Unagidon
-    <tag>k__BackingField: Dish
+    <KoreanName>k__BackingField: 53
+    <tag>k__BackingField: 2
     <ID>k__BackingField: 75
     <price>k__BackingField: 1000
     <level>k__BackingField: 8
     <Prefab>k__BackingField: {fileID: 4201431055077167541, guid: 59607a41e19e64e8f99077b4087ad8a1, type: 3}
+    <icon>k__BackingField: {fileID: 2800000, guid: 0e348608327d14d609f34a994a4f8817, type: 3}
   - <Name>k__BackingField: MisoSoup
-    <tag>k__BackingField: Dish
+    <KoreanName>k__BackingField: 56
+    <tag>k__BackingField: 2
     <ID>k__BackingField: 76
     <price>k__BackingField: 1000
     <level>k__BackingField: 4
     <Prefab>k__BackingField: {fileID: 4117434976560213589, guid: 0398a3fe9d59b4d9ebb10be843eadf30, type: 3}
+    <icon>k__BackingField: {fileID: 2800000, guid: 078b1747f4f0a4578b49cb53db59b038, type: 3}
   - <Name>k__BackingField: Tea
-    <tag>k__BackingField: Dish
+    <KoreanName>k__BackingField: 57
+    <tag>k__BackingField: 2
     <ID>k__BackingField: 77
     <price>k__BackingField: 1000
     <level>k__BackingField: 2
     <Prefab>k__BackingField: {fileID: 2906252503343478693, guid: d8af5ff02e09a4025b5e4dd800f35a83, type: 3}
+    <icon>k__BackingField: {fileID: 2800000, guid: b2ead2aec46ff4b0d8efd2628cbc3439, type: 3}

--- a/Assets/Scripts/CustomerManager.cs
+++ b/Assets/Scripts/CustomerManager.cs
@@ -217,4 +217,4 @@ public class UniformCustomerWave: ICustomerWave {
             yield return new WaitForSeconds(spawnInterval);
         }
     }
-}
+} 

--- a/Assets/Scripts/FoodDatabaseSO.cs
+++ b/Assets/Scripts/FoodDatabaseSO.cs
@@ -1,9 +1,6 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using Unity.VisualScripting.Antlr3.Runtime;
 using UnityEngine;
-using UnityEngine.UI;
 
 /// <summary>
 /// 음식(Food) 데이터베이스(재료, 중간단계, 요리)를 관리하는 ScriptableObject
@@ -35,7 +32,7 @@ public class FoodData
     /// 음식 한글 이름
     /// </summary>
     [field: SerializeField]
-    public Yogaewonsil.Common.Food KoreanName { get; private set; }
+    public Yogaewonsil.Common.Food food { get; private set; }
 
     /// <summary>
     /// 음식 태크 (재료, 중간단계, 요리)

--- a/Assets/Scripts/FoodDatabaseSO.cs
+++ b/Assets/Scripts/FoodDatabaseSO.cs
@@ -26,10 +26,10 @@ public class FoodData
     /// 음식 이름
     /// </summary>
     [field: SerializeField]
-    public string Name { get; private set; }
+    public string name { get; private set; }
     
     /// <summary>
-    /// 음식 한글 이름
+    /// 음식
     /// </summary>
     [field: SerializeField]
     public Yogaewonsil.Common.Food food { get; private set; }
@@ -44,7 +44,7 @@ public class FoodData
     /// 음식 고유 ID
     /// </summary>
     [field: SerializeField]
-    public int ID { get; private set; }
+    public int id { get; private set; }
     
     /// <summary>
     /// 음식 가격 
@@ -62,7 +62,7 @@ public class FoodData
     /// 음식 프리팹 
     /// </summary>
     [field: SerializeField]
-    public GameObject Prefab { get; private set; }
+    public GameObject prefab { get; private set; }
 
     /// <summary>
     /// 음식 아이콘

--- a/Assets/Scripts/FoodDatabaseSO.cs
+++ b/Assets/Scripts/FoodDatabaseSO.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using Unity.VisualScripting.Antlr3.Runtime;
 using UnityEngine;
+using UnityEngine.UI;
 
 /// <summary>
 /// 음식(Food) 데이터베이스(재료, 중간단계, 요리)를 관리하는 ScriptableObject
@@ -28,12 +30,18 @@ public class FoodData
     /// </summary>
     [field: SerializeField]
     public string Name { get; private set; }
+    
+    /// <summary>
+    /// 음식 한글 이름
+    /// </summary>
+    [field: SerializeField]
+    public Yogaewonsil.Common.Food KoreanName { get; private set; }
 
     /// <summary>
     /// 음식 태크 (재료, 중간단계, 요리)
     /// </summary>
     [field: SerializeField]
-    public string tag { get; private set; }
+    public FoodTag tag { get; private set; }
 
     /// <summary>
     /// 음식 고유 ID
@@ -58,4 +66,10 @@ public class FoodData
     /// </summary>
     [field: SerializeField]
     public GameObject Prefab { get; private set; }
+
+    /// <summary>
+    /// 음식 아이콘
+    /// </summary>
+    [field: SerializeField]
+    public Texture icon { get; private set; }
 }

--- a/Assets/Scripts/FoodTag.cs
+++ b/Assets/Scripts/FoodTag.cs
@@ -1,0 +1,10 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public enum FoodTag
+    {
+        Ingredient,
+        Predish,
+        Dish
+    }

--- a/Assets/Scripts/FoodTag.cs.meta
+++ b/Assets/Scripts/FoodTag.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 814f14bff16be4971ad8c2c388b80406
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### 요약

Food, FoodTag 및 아이콘 필드 추가했습니다.

### 변경 사항

Food, FoodTag 및 아이콘 필드 추가했습니다.

### 테스트 결과

<img width="277" alt="Screenshot 2024-11-26 at 10 15 18 PM" src="https://github.com/user-attachments/assets/10e28a4f-1797-4f8a-9279-e592e9d87af5">


### 참고 사항

- Predish 아이콘은 아직 없음
- Predish 영문명과 한글명이 잘 매칭되지 않아 우선은 대충 끼워맞춘 상태 (상언/도현님께서 수요일에 알려주시면 감사하겠습니다)

### 리뷰 요청

- 하늘님이 작성하신 레시피 코드와 상언님이 올려주신 레시피 구현 현황 리스트와 안 맞는 부분 있음 (ex. 재료 - 참치 / (일반참치, 고급참치))

### 관련 Issue

- SCRUM-211