### PR TITLE
[SCRUM-36] 시작 화면 Grid 삭제

### DIFF
--- a/Assets/Scenes/StartScene.unity
+++ b/Assets/Scenes/StartScene.unity
@@ -44541,7 +44541,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &1057269675
 Transform:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
### 요약

시작 화면 StartScene Grid 삭제했습니다. 

### 변경 사항

- 시작 화면 StartScene Grid 삭제했습니다. 

### 테스트 결과

변경 전

<img width="957" alt="Screenshot 2024-12-17 at 6 41 33 PM" src="https://github.com/user-attachments/assets/bcd5c681-8179-4ef8-8cbe-3cfbb9daf4e5" />
 

변경 후
<img width="957" alt="Screenshot 2024-12-17 at 6 41 19 PM" src="https://github.com/user-attachments/assets/05b859e2-f46d-4ad7-8846-2515c663c12c" />

### 참고 사항


### 리뷰 요청

에러 없이 잘 돌아가는지

### 관련 Issue

- SCRUM-36